### PR TITLE
feat: create a new API for SMAT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,36 @@ This project aims to detect semantic conflicts by generating and running test su
   <li>As a result, the file <b>results_semantic_study.csv</b> will be created. If you want to analyze other merge scenarios, you must provide a file the same information provided in our dataset.</li>
 </ul>
 
+## Providing input
+SMAT allows the user to provide many scenarios for analysis using a JSON file. This JSON file consists of an array including each scenario that's going to be evaluated. The JSON file has the following structure:
+```json
+[
+  {
+    "projectName": "spring-boot",
+    "runAnalysis": true,
+    "scenarioCommits": {
+      "base": "7578f2f824aac027529878810b76ee176b39e73a",
+      "left": "0d00039ae7d01538de3f813b17d125dc5fdd5706",
+      "right": "1c21f54bf91283d70e04c49ea09a4c05a885d7ac",
+      "merge": "3eebbe1c8aed529e6903e78476492592ce0b0049"
+    },
+    "targets": {
+      "org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory": [
+        "createDeploymentManager(org.springframework.boot.context.embedded.ServletContextInitializer[])"
+      ]
+    },
+    "scenarioJars": {
+      "base": "/home/jpedroh/Projetos/cin/testes-smat/spring-boot/7578f2f824aac027529878810b76ee176b39e73a-createDeploymentManager.jar",
+      "left": "/home/jpedroh/Projetos/cin/testes-smat/spring-boot/0d00039ae7d01538de3f813b17d125dc5fdd5706-createDeploymentManager.jar",
+      "right": "/home/jpedroh/Projetos/cin/testes-smat/spring-boot/1c21f54bf91283d70e04c49ea09a4c05a885d7ac-createDeploymentManager.jar",
+      "merge": "/home/jpedroh/Projetos/cin/testes-smat/spring-boot/3eebbe1c8aed529e6903e78476492592ce0b0049-createDeploymentManager.jar"
+    },
+    "jarType": "transformation"
+  }
+]
+```
+The scenarios file path can then be informed in the `env-config.json` file using the `input_path` field.
+
 ## Attentions When Using Windows
 If you use Windows as your operating system, when you clone this project, you will probably receive an error message due to the size of a few file names. This problem will make it impossible for you to clone this repository.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,11 @@
+# Architecture overview
+
+Currently, this is an overview of SMAT architecture.
+
+```mermaid
+graph TD
+    A[SMAT] ==> B[Test Generation]
+    B ==> C[Test Execution]
+    B ==> D[Test Dynamic Analysis]
+    A ==> E[Output Generation]
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,8 @@
-# Architecture overview
+# Architecture
+
+This documentation dive into details of SMAT architecture.
+
+## Overview
 
 Currently, this is an overview of SMAT architecture.
 

--- a/nimrod/input_parsing/input_parser.py
+++ b/nimrod/input_parsing/input_parser.py
@@ -1,0 +1,79 @@
+import csv
+import json
+from abc import ABC, abstractmethod
+
+from nimrod.input_parsing.smat_input import ScenarioInformation, SmatInput
+
+
+class InputParser(ABC):
+    @abstractmethod
+    def parse_input(self, file_path: str) -> "list[SmatInput]":
+        pass
+
+
+class JsonInputParser(InputParser):
+    def parse_input(self, file_path: str) -> "list[SmatInput]":
+        with open(file_path, 'r') as json_data:
+            json_data = json.load(json_data)
+
+        return [self._convert_to_internal_representation(scenario) for scenario in json_data]
+
+    def _convert_to_internal_representation(self, scenario: "dict[str]"):
+        scenario_commits_json = scenario.get('scenarioCommits')
+        scenario_jars_json = scenario.get('scenarioJars')
+
+        return SmatInput(
+            project_name=scenario.get('projectName'),
+            run_analysis=scenario.get('runAnalysis'),
+            scenario_commits=ScenarioInformation(
+                base=scenario_commits_json.get('base'),
+                left=scenario_commits_json.get('left'),
+                right=scenario_commits_json.get('right'),
+                ancestor=scenario_commits_json.get('ancestor'),
+            ),
+            targets=scenario.get('targets'),
+            scenario_jars=ScenarioInformation(
+                base=scenario_jars_json.get('base'),
+                left=scenario_jars_json.get('left'),
+                right=scenario_jars_json.get('right'),
+                ancestor=scenario_jars_json.get('ancestor'),
+            ),
+            jar_type=scenario.get('jarType')
+        )
+
+
+class CsvInputParser(InputParser):
+    def parse_input(self, file_path: str) -> "list[SmatInput]":
+        with open(file_path, 'r') as csv_file:
+            csv_data = csv.reader(csv_file, delimiter=',')
+            return [self._convert_to_internal_representation(scenario) for scenario in csv_data]
+
+    def _convert_to_internal_representation(self, row: "list[str]"):
+        return SmatInput(
+            project_name=row[0],
+            run_analysis=row[1] == "true",
+            scenario_commits=ScenarioInformation(
+                base=row[2],
+                left=row[3],
+                right=row[4],
+                ancestor=row[5],
+            ),
+            targets=self._build_targets_from_old_entry(row[6], row[7]),
+            scenario_jars=ScenarioInformation(
+                base=row[10],
+                left=row[11],
+                right=row[12],
+                ancestor=row[13],
+            ),
+            jar_type=row[14]
+        )
+
+    def _build_targets_from_old_entry(self, class_list: str, method_list: str):
+        classes = class_list.split(' | ')
+        targets = dict()
+        for class_name in classes:
+            targets[class_name] = []
+
+        targets[classes[0]] = [method_list.replace('|', ",")]
+
+        return targets

--- a/nimrod/input_parsing/input_parser.py
+++ b/nimrod/input_parsing/input_parser.py
@@ -29,14 +29,14 @@ class JsonInputParser(InputParser):
                 base=scenario_commits_json.get('base'),
                 left=scenario_commits_json.get('left'),
                 right=scenario_commits_json.get('right'),
-                ancestor=scenario_commits_json.get('ancestor'),
+                merge=scenario_commits_json.get('merge'),
             ),
             targets=scenario.get('targets'),
             scenario_jars=ScenarioInformation(
                 base=scenario_jars_json.get('base'),
                 left=scenario_jars_json.get('left'),
                 right=scenario_jars_json.get('right'),
-                ancestor=scenario_jars_json.get('ancestor'),
+                merge=scenario_jars_json.get('merge'),
             ),
             jar_type=scenario.get('jarType')
         )
@@ -56,14 +56,14 @@ class CsvInputParser(InputParser):
                 base=row[2],
                 left=row[3],
                 right=row[4],
-                ancestor=row[5],
+                merge=row[5],
             ),
             targets=self._build_targets_from_old_entry(row[6], row[7]),
             scenario_jars=ScenarioInformation(
                 base=row[10],
                 left=row[11],
                 right=row[12],
-                ancestor=row[13],
+                merge=row[13],
             ),
             jar_type=row[14]
         )

--- a/nimrod/input_parsing/input_parser.py
+++ b/nimrod/input_parsing/input_parser.py
@@ -4,7 +4,8 @@ from abc import ABC, abstractmethod
 
 from nimrod.input_parsing.smat_input import ScenarioInformation, SmatInput
 
-
+# This interface is responsible for parsing user input from a file into SMAT internal model.
+# If you wish to implement a new parser, just create a new implementation of it.
 class InputParser(ABC):
     @abstractmethod
     def parse_input(self, file_path: str) -> "list[SmatInput]":

--- a/nimrod/input_parsing/smat_input.py
+++ b/nimrod/input_parsing/smat_input.py
@@ -9,8 +9,8 @@ class SmatInput:
 
 
 class ScenarioInformation:
-    def __init__(self, base: str, left: str, right: str, ancestor: str):
+    def __init__(self, base: str, left: str, right: str, merge: str):
         self.base = base
         self.left = left
         self.right = right
-        self.ancestor = ancestor
+        self.merge = merge

--- a/nimrod/input_parsing/smat_input.py
+++ b/nimrod/input_parsing/smat_input.py
@@ -1,0 +1,16 @@
+class SmatInput:
+    def __init__(self, project_name: str, run_analysis: bool, scenario_commits: "ScenarioInformation", targets: "dict[str, list[str]]", scenario_jars: "ScenarioInformation", jar_type: str):
+        self.project_name = project_name
+        self.run_analysis = run_analysis
+        self.scenario_commits = scenario_commits
+        self.targets = targets
+        self.scenario_jars = scenario_jars
+        self.jar_type = jar_type
+
+
+class ScenarioInformation:
+    def __init__(self, base: str, left: str, right: str, ancestor: str):
+        self.base = base
+        self.left = left
+        self.right = right
+        self.ancestor = ancestor

--- a/nimrod/proj/project_dependencies.py
+++ b/nimrod/proj/project_dependencies.py
@@ -27,7 +27,7 @@ class Project_dependecies:
         #self.tests_dst = self.config["tests_dst"]
         self.project = GitProject(path_local_project, path_local_module_analysis, project_name)
         self.projects_folder = self.config["projects_folder"]
-        self.path_hash_csv = self.config["path_hash_csv"]
+        # self.path_hash_csv = self.config["path_hash_csv"]
         self.path_output_csv = self.config["path_output_csv"]
 
     def create_directory_test_destination(self):

--- a/nimrod/proj/project_dependencies.py
+++ b/nimrod/proj/project_dependencies.py
@@ -27,7 +27,6 @@ class Project_dependecies:
         #self.tests_dst = self.config["tests_dst"]
         self.project = GitProject(path_local_project, path_local_module_analysis, project_name)
         self.projects_folder = self.config["projects_folder"]
-        # self.path_hash_csv = self.config["path_hash_csv"]
         self.path_output_csv = self.config["path_output_csv"]
 
     def create_directory_test_destination(self):

--- a/nimrod/proj/semantic_study.py
+++ b/nimrod/proj/semantic_study.py
@@ -66,17 +66,17 @@ if __name__ == '__main__':
                 local_file_coverage = semantic_study_obj.output_coverage_metric.output_file_path
                 coverage_report = Coverage_Report()
                 merge = MergeScenario(merge_information=row)
-                for i in range(0, 1):
-                    evosuite = semantic_study_obj.evosuite_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.EVOSUITE.value)
-                    semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite, row[6], row[7], row[14])
-                    evosuite_diff = semantic_study_obj.evosuite_diff_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.DIFF_EVOSUITE.value)
-                    semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite_diff, row[6], row[7], row[14])
-                    randoop = semantic_study_obj.randoop_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.RANDOOP.value)
-                    semantic_study_obj.output_semantic_conflict.write_output_line(row[0], randoop, row[6], row[7], row[14])
-                    randoop_modified = semantic_study_obj.randoop_modified_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.RANDOOP_MOD.value)
-                    semantic_study_obj.output_semantic_conflict.write_output_line(row[0], randoop_modified, row[6], row[7], row[14])
-                    semantic_study_obj.report_analysis.start_analysis(randoop, randoop_modified)
-                    coverage_report.generate_report(semantic_study_obj, merge, row[2], randoop, randoop_modified, row[0], row[14])
+                
+                evosuite = semantic_study_obj.evosuite_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[9], row[10], row[11], row[12], row[5], row[3], row[4], row[2], Tools.EVOSUITE.value)
+                semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite, row[6], row[7], row[14])
+                # evosuite_diff = semantic_study_obj.evosuite_diff_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.DIFF_EVOSUITE.value)
+                # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite_diff, row[6], row[7], row[14])
+                # randoop = semantic_study_obj.randoop_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.RANDOOP.value)
+                # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], randoop, row[6], row[7], row[14])
+                # randoop_modified = semantic_study_obj.randoop_modified_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.RANDOOP_MOD.value)
+                # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], randoop_modified, row[6], row[7], row[14])
+                # semantic_study_obj.report_analysis.start_analysis(randoop, randoop_modified)
+                # coverage_report.generate_report(semantic_study_obj, merge, row[2], randoop, randoop_modified, row[0], row[14])
 
         semantic_study_obj = semantic_study()
         semantic_study_obj.results_summary.generate_summary(semantic_study_obj.output_semantic_conflict.output_file_path, semantic_study_obj.output_coverage_metric.output_file_path);

--- a/nimrod/proj/semantic_study.py
+++ b/nimrod/proj/semantic_study.py
@@ -1,24 +1,26 @@
-import csv
+import logging
 import os
 from collections import namedtuple
 
+from nimrod.input_parsing.input_parser import CsvInputParser, JsonInputParser
+from nimrod.input_parsing.smat_input import SmatInput
 from nimrod.proj.project_dependencies import Project_dependecies
 from nimrod.project_info.git_project import GitProject
 from nimrod.project_info.merge_scenario import MergeScenario
-from nimrod.report.output_behavior_change_commit_pair import Output_behavior_change_commit_pair
+from nimrod.report.output_behavior_change_commit_pair import \
+    Output_behavior_change_commit_pair
 from nimrod.report.output_coverage_metric import Output_coverage_metric
 from nimrod.report.output_report import Output_report
 from nimrod.report.output_semantic_conflicts import Output_semantic_conflicts
-from nimrod.report_metrics.coverage.coverage_report import Coverage_Report
 from nimrod.report.report_analysis import Report_Analysis
 from nimrod.report.result_summary import Result_Summary
+from nimrod.report_metrics.coverage.coverage_report import Coverage_Report
 from nimrod.setup_tools.evosuite_diff_setup import Evosuite_Diff_setup
 from nimrod.setup_tools.evosuite_setup import Evosuite_setup
 from nimrod.setup_tools.randoop_modified_setup import Randoop_Modified_setup
 from nimrod.setup_tools.randoop_setup import Randoop_setup
 from nimrod.setup_tools.tools import Tools
 from nimrod.tests.utils import get_config, setup_logging
-import logging
 
 NimrodResult = namedtuple('NimrodResult', ['maybe_equivalent', 'not_equivalent',
                                            'coverage', 'differential',
@@ -37,53 +39,62 @@ class semantic_study:
         self.randoop_modified_setup = Randoop_Modified_setup()
         self.report_analysis = Report_Analysis()
 
-        self.output_semantic_conflict = Output_semantic_conflicts(os.getcwd().replace("/nimrod/proj","/")+'/output-test-dest/' if os.getcwd().__contains__("/nimrod/proj") else os.getcwd() + "/output-test-dest/", "test_conflicts")
-        self.output_coverage_metric = Output_coverage_metric(os.getcwd().replace("/nimrod/proj","/")+'/output-test-dest/' if os.getcwd().__contains__("/nimrod/proj") else os.getcwd() + "/output-test-dest/", "result_cobertura")
+        self.output_semantic_conflict = Output_semantic_conflicts(os.getcwd().replace(
+            "/nimrod/proj", "/")+'/output-test-dest/' if os.getcwd().__contains__("/nimrod/proj") else os.getcwd() + "/output-test-dest/", "test_conflicts")
+        self.output_coverage_metric = Output_coverage_metric(os.getcwd().replace(
+            "/nimrod/proj", "/")+'/output-test-dest/' if os.getcwd().__contains__("/nimrod/proj") else os.getcwd() + "/output-test-dest/", "result_cobertura")
 
         self.output_report = Output_report(config["path_output_csv"])
-        self.results_summary = Result_Summary(os.getcwd().replace("/nimrod/proj","/")+'/output-test-dest/' if os.getcwd().__contains__("/nimrod/proj") else os.getcwd() + "/output-test-dest/", "results_summary");
-
-    def set_git_project(self, path):
-        self.project = GitProject(path)
-
-    def get_commit_pairs(self, row):
-        return [[row[11],row[10],row[3],row[5]], [row[12],row[10],row[4],row[5]], [row[11],row[13],row[3],row[2]], [row[12],row[13],row[4],row[2]]]
-
-    def get_commit_triples(self, row):
-        return [[row[10],row[11],row[13],row[5], row[3], row[2]], [row[10],row[12],row[13],row[5], row[4], row[2]]]
+        self.results_summary = Result_Summary(os.getcwd().replace("/nimrod/proj", "/")+'/output-test-dest/' if os.getcwd(
+        ).__contains__("/nimrod/proj") else os.getcwd() + "/output-test-dest/", "results_summary")
 
 
 if __name__ == '__main__':
     config = get_config()
     setup_logging()
 
-    with open(config['path_hash_csv']) as csv_file:
-        csv_reader = csv.reader(csv_file, delimiter=',')
-        local_file_result = ""
-        local_file_coverage = ""
-        for row in csv_reader:
-            if row[1] == "true":
-                logging.info("Starting Semantic Conflict Analysis for project %s", row[0])
-                semantic_study_obj = semantic_study(project_name=row[0])
-                local_file_result = semantic_study_obj.output_semantic_conflict.output_file_path
-                local_file_coverage = semantic_study_obj.output_coverage_metric.output_file_path
-                coverage_report = Coverage_Report()
-                merge = MergeScenario(merge_information=row)
-                
-                evosuite = semantic_study_obj.evosuite_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[9], row[10], row[11], row[12], row[5], row[3], row[4], row[2], Tools.EVOSUITE.value)
-                semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite, row[6], row[7], row[14])
-                # evosuite_diff = semantic_study_obj.evosuite_diff_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.DIFF_EVOSUITE.value)
-                # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite_diff, row[6], row[7], row[14])
-                randoop = semantic_study_obj.randoop_setup.run_tool_for_semantic_conflict_detection(
-                    semantic_study_obj, merge, row[9], row[10], row[11], row[12], row[5], row[3], row[4], row[2], Tools.RANDOOP.value)
-                semantic_study_obj.output_semantic_conflict.write_output_line(
-                    row[0], randoop, row[6], row[7], row[14])
-                # randoop_modified = semantic_study_obj.randoop_modified_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.RANDOOP_MOD.value)
-                # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], randoop_modified, row[6], row[7], row[14])
-                # semantic_study_obj.report_analysis.start_analysis(randoop, randoop_modified)
-                # coverage_report.generate_report(semantic_study_obj, merge, row[2], randoop, randoop_modified, row[0], row[14])
-            else:
-                logging.info("Ignoring Semantic Conflict Analysis for project %s", row[0])
+    parsed_input: "list[SmatInput]" = None
+    if config.get('input_path'):
+        parsed_input = JsonInputParser().parse_input(config.get('input_path'))
+    elif config.get('path_hash_csv'):
+        logging.WARN(
+            'DEPRECATED: Providing input data with `path_hash_csv` is deprecated and will be removed in future versions of SMAT. Use `input_path` instead.')
+        parsed_input = CsvInputParser().parse_input(config.get('path_hash_csv'))
+    else:
+        logging.FATAL('Non input file provided')
+        exit(1)
+
+    scenarios = [
+        scenario for scenario in parsed_input if scenario.run_analysis]
+    for scenario in scenarios:
+        logging.info(
+            "Starting Semantic Conflict Analysis for project %s", scenario.project_name)
+
+        semantic_study_obj = semantic_study(project_name=scenario.project_name)
+        local_file_result = semantic_study_obj.output_semantic_conflict.output_file_path
+        local_file_coverage = semantic_study_obj.output_coverage_metric.output_file_path
+        coverage_report = Coverage_Report()
+        merge = MergeScenario()
+
+        evosuite = semantic_study_obj.evosuite_setup.run_tool_for_semantic_conflict_detection(
+            semantic_study_obj, merge, Tools.EVOSUITE.value, scenario)
+        semantic_study_obj.output_semantic_conflict.write_output_line(
+            scenario.project_name, evosuite, (' | ').join(scenario.targets.keys()), '', scenario.jar_type)
+        # evosuite_diff = semantic_study_obj.evosuite_diff_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.DIFF_EVOSUITE.value)
+        # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite_diff, row[6], row[7], row[14])
+        randoop = semantic_study_obj.randoop_setup.run_tool_for_semantic_conflict_detection(
+            semantic_study_obj, merge, Tools.RANDOOP.value, scenario)
+        semantic_study_obj.output_semantic_conflict.write_output_line(
+            scenario.project_name, randoop, (' | ').join(scenario.targets.keys()), '', scenario.jar_type)
+        randoop_modified = semantic_study_obj.randoop_modified_setup.run_tool_for_semantic_conflict_detection(
+            semantic_study_obj, merge, Tools.RANDOOP_MOD.value, scenario)
+        semantic_study_obj.output_semantic_conflict.write_output_line(
+            scenario.project_name, randoop_modified, (' | ').join(scenario.targets.keys()), '', scenario.jar_type)
+        semantic_study_obj.report_analysis.start_analysis(
+            randoop, randoop_modified)
+        coverage_report.generate_report(semantic_study_obj, merge, scenario.scenario_commits.base,
+                                        randoop, randoop_modified, scenario.project_name, scenario.jar_type)
 
         semantic_study_obj = semantic_study()
-        semantic_study_obj.results_summary.generate_summary(semantic_study_obj.output_semantic_conflict.output_file_path, semantic_study_obj.output_coverage_metric.output_file_path);
+        semantic_study_obj.results_summary.generate_summary(
+            semantic_study_obj.output_semantic_conflict.output_file_path, semantic_study_obj.output_coverage_metric.output_file_path)

--- a/nimrod/proj/semantic_study.py
+++ b/nimrod/proj/semantic_study.py
@@ -17,7 +17,8 @@ from nimrod.setup_tools.evosuite_setup import Evosuite_setup
 from nimrod.setup_tools.randoop_modified_setup import Randoop_Modified_setup
 from nimrod.setup_tools.randoop_setup import Randoop_setup
 from nimrod.setup_tools.tools import Tools
-from nimrod.tests.utils import get_config
+from nimrod.tests.utils import get_config, setup_logging
+import logging
 
 NimrodResult = namedtuple('NimrodResult', ['maybe_equivalent', 'not_equivalent',
                                            'coverage', 'differential',
@@ -51,16 +52,18 @@ class semantic_study:
     def get_commit_triples(self, row):
         return [[row[10],row[11],row[13],row[5], row[3], row[2]], [row[10],row[12],row[13],row[5], row[4], row[2]]]
 
-if __name__ == '__main__':
 
+if __name__ == '__main__':
     config = get_config()
+    setup_logging()
+
     with open(config['path_hash_csv']) as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=',')
         local_file_result = ""
         local_file_coverage = ""
         for row in csv_reader:
             if row[1] == "true":
-                print("Semantic Conflict Analysis")
+                logging.info("Starting Semantic Conflict Analysis for project %s", row[0])
                 semantic_study_obj = semantic_study(project_name=row[0])
                 local_file_result = semantic_study_obj.output_semantic_conflict.output_file_path
                 local_file_coverage = semantic_study_obj.output_coverage_metric.output_file_path
@@ -79,6 +82,8 @@ if __name__ == '__main__':
                 # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], randoop_modified, row[6], row[7], row[14])
                 # semantic_study_obj.report_analysis.start_analysis(randoop, randoop_modified)
                 # coverage_report.generate_report(semantic_study_obj, merge, row[2], randoop, randoop_modified, row[0], row[14])
+            else:
+                logging.info("Ignoring Semantic Conflict Analysis for project %s", row[0])
 
         semantic_study_obj = semantic_study()
         semantic_study_obj.results_summary.generate_summary(semantic_study_obj.output_semantic_conflict.output_file_path, semantic_study_obj.output_coverage_metric.output_file_path);

--- a/nimrod/proj/semantic_study.py
+++ b/nimrod/proj/semantic_study.py
@@ -80,8 +80,10 @@ if __name__ == '__main__':
             semantic_study_obj, merge, Tools.EVOSUITE.value, scenario)
         semantic_study_obj.output_semantic_conflict.write_output_line(
             scenario.project_name, evosuite, (' | ').join(scenario.targets.keys()), '', scenario.jar_type)
-        # evosuite_diff = semantic_study_obj.evosuite_diff_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.DIFF_EVOSUITE.value)
-        # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite_diff, row[6], row[7], row[14])
+        evosuite_diff = semantic_study_obj.evosuite_diff_setup.run_tool_for_semantic_conflict_detection(
+            semantic_study_obj, merge, Tools.DIFF_EVOSUITE.value, scenario)
+        semantic_study_obj.output_semantic_conflict.write_output_line(
+            scenario.project_name, evosuite_diff, (' | ').join(scenario.targets.keys()), '', scenario.jar_type)
         randoop = semantic_study_obj.randoop_setup.run_tool_for_semantic_conflict_detection(
             semantic_study_obj, merge, Tools.RANDOOP.value, scenario)
         semantic_study_obj.output_semantic_conflict.write_output_line(
@@ -93,7 +95,7 @@ if __name__ == '__main__':
         semantic_study_obj.report_analysis.start_analysis(
             randoop, randoop_modified)
         coverage_report.generate_report(semantic_study_obj, merge, scenario.scenario_commits.base,
-                                        randoop, randoop_modified, scenario.project_name, scenario.jar_type)
+                                        randoop, randoop_modified, scenario.project_name, scenario.jar_type, scenario)
 
         semantic_study_obj = semantic_study()
         semantic_study_obj.results_summary.generate_summary(

--- a/nimrod/proj/semantic_study.py
+++ b/nimrod/proj/semantic_study.py
@@ -71,8 +71,10 @@ if __name__ == '__main__':
                 semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite, row[6], row[7], row[14])
                 # evosuite_diff = semantic_study_obj.evosuite_diff_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.DIFF_EVOSUITE.value)
                 # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], evosuite_diff, row[6], row[7], row[14])
-                # randoop = semantic_study_obj.randoop_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.RANDOOP.value)
-                # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], randoop, row[6], row[7], row[14])
+                randoop = semantic_study_obj.randoop_setup.run_tool_for_semantic_conflict_detection(
+                    semantic_study_obj, merge, row[9], row[10], row[11], row[12], row[5], row[3], row[4], row[2], Tools.RANDOOP.value)
+                semantic_study_obj.output_semantic_conflict.write_output_line(
+                    row[0], randoop, row[6], row[7], row[14])
                 # randoop_modified = semantic_study_obj.randoop_modified_setup.run_tool_for_semantic_conflict_detection(semantic_study_obj, merge, row[10], row[11], row[12], row[13], row[5], row[3], row[4], row[2], Tools.RANDOOP_MOD.value)
                 # semantic_study_obj.output_semantic_conflict.write_output_line(row[0], randoop_modified, row[6], row[7], row[14])
                 # semantic_study_obj.report_analysis.start_analysis(randoop, randoop_modified)

--- a/nimrod/project_info/commit.py
+++ b/nimrod/project_info/commit.py
@@ -8,6 +8,18 @@ class Commit:
         self.sut_classes = sut_class.split(" | ")
         self.sut_class = self.sut_classes[0]
         self.sut_method = self.sut_class.replace(" ","")+"."+changed_method.replace("|",",")
+        self.targets: dict[str, list[str]] = self.resolve_targets(sut_class)
+
+    def resolve_targets(self, encoded_targets: str):
+        targets = dict()
+        tuples = encoded_targets.split('$')
+
+        for tuple in tuples:
+            [fqcn, methods] = tuple.split('=')
+            methods_list = methods.split(':') if methods != "" else []
+            targets[fqcn] = [x.replace('|', ':') for x in methods_list]
+
+        return targets
 
     def get_merge_hash(self):
         return self.merge_hash

--- a/nimrod/project_info/commit.py
+++ b/nimrod/project_info/commit.py
@@ -1,25 +1,13 @@
 class Commit:
 
-    def __init__(self, base_hash, left_hash, right_hash, merge_hash, sut_class, changed_method=""):
+    def __init__(self, base_hash="", left_hash="", right_hash="", merge_hash="", sut_class="", changed_method=""):
         self.merge_hash = merge_hash
         self.left_hash = left_hash
         self.right_hash = right_hash
         self.base_hash = base_hash
         self.sut_classes = sut_class.split(" | ")
         self.sut_class = self.sut_classes[0]
-        self.sut_method = self.sut_class.replace(" ","")+"."+changed_method.replace("|",",")
-        self.targets: dict[str, list[str]] = self.resolve_targets(sut_class)
-
-    def resolve_targets(self, encoded_targets: str):
-        targets = dict()
-        tuples = encoded_targets.split('$')
-
-        for tuple in tuples:
-            [fqcn, methods] = tuple.split('=')
-            methods_list = methods.split(':') if methods != "" else []
-            targets[fqcn] = [x.replace('|', ':') for x in methods_list]
-
-        return targets
+        self.sut_method = self.sut_class.replace(" ", "")+"."+changed_method.replace("|", ",")
 
     def get_merge_hash(self):
         return self.merge_hash

--- a/nimrod/project_info/merge_scenario.py
+++ b/nimrod/project_info/merge_scenario.py
@@ -6,16 +6,7 @@ class MergeScenario:
 
     def __init__(self, path_local_clone="", merge_information=""):
         self.path_local_clone = path_local_clone
-        self.path_merge_scenarios = merge_information
-        self.merge_scenario = self.identify_merge_scenarios(merge_information)
+        self.merge_scenario = Commit()
 
     def get_merge_scenarios(self):
         return self.merge_scenarios
-
-    def identify_merge_scenarios(self, merge_information):
-        commit = []
-        if (merge_information[1] != "commit_pairs"):
-            commit = Commit(merge_information[5], merge_information[3], merge_information[4], merge_information[2], merge_information[6], merge_information[7])#, merge_information[5])#, merge_information[6], merge_information[7])
-        else:
-            commit = Commit(merge_information[2], merge_information[3], "", merge_information[2], merge_information[6], merge_information[7])
-        return commit

--- a/nimrod/report_metrics/coverage/coverage_report.py
+++ b/nimrod/report_metrics/coverage/coverage_report.py
@@ -1,7 +1,9 @@
 import codecs
 import os
+from struct import pack
 
 from bs4 import BeautifulSoup
+from nimrod.input_parsing.smat_input import SmatInput
 
 from nimrod.setup_tools.setup_tool import Setup_tool
 from nimrod.tools.bin import JACOCOAGENT
@@ -10,12 +12,10 @@ from nimrod.tools.suite_generator import Suite
 
 
 class Coverage_Report(Setup_tool):
-    # scenario.merge_scenario.sut_class
-
-    def generate_report(self, evo, scenario, commitMerge, toolOneSuites, toolTwoSuites, projectName, jar_type=None):
-        listaPacoteMetodoClasse = self.recuperaClassePacoteMetodo(scenario.merge_scenario.sut_method.replace("|", ","), scenario.merge_scenario.sut_class)
-
-        listaPartesBasicasReport = ["target_commit", "test_suite_commit", "projeto"]
+    def generate_report(self, evo, scenario, commitMerge, toolOneSuites, toolTwoSuites, projectName, jar_type=None, input: SmatInput = None):
+        listaPacoteMetodoClasse = self._decomposeTarget(input.targets)
+        listaPartesBasicasReport = [
+            "target_commit", "test_suite_commit", "projeto"]
         listaCoberturaProjeto = ["randoop X: cobertura metodo SUA", "randoop Y: cobertura metodo SUA",
                                  "randoop X: cobertura classe SUA", "randoop Y: cobertura classe SUA",
                                  "randoop X: cobertura linha SUA", "randoop Y: cobertura linha SUA"]
@@ -25,12 +25,12 @@ class Coverage_Report(Setup_tool):
                                 "randoop X: cobertura instruction MUA", "randoop Y: cobertura instruction MUA",
                                 "randoop X: cobertura branch MUA", "randoop Y: cobertura branch MUA"]
 
-
         jacoco = Jacoco(java=evo.project_dep.java)
 
         try:
             for i in range(2):
-                test_suite_tool_one = self.get_valid_test_suite(toolOneSuites, i*4, i*4+3)
+                test_suite_tool_one = self.get_valid_test_suite(
+                    toolOneSuites, i*4, i*4+3)
                 #dadosParaGravacaoRandoopX = self.retornaDadosParaAnalise(evo, toolOneSuites[0][2], toolOneSuites[0][7], jacoco,
                 if (test_suite_tool_one != None):
                     #self.test_suite = self.get_new_suite(test_suite_tool_one[2], test_suite_tool_one[7])
@@ -42,9 +42,10 @@ class Coverage_Report(Setup_tool):
                         test_suite_commit = commitMerge
 
                     dadosParaGravacaoRandoopX = self.retornaDadosParaAnalise(evo, test_suite_path_one, test_suite_commit, jacoco,
-                                                                             scenario.merge_scenario.sut_class,
-                                                                             listaPacoteMetodoClasse)
-                    test_suite_tool_two = self.get_valid_test_suite(toolTwoSuites, i*4, i*4+3)
+                                                                             list(input.targets.keys())[0],
+                                                                             listaPacoteMetodoClasse, input.targets)
+                    test_suite_tool_two = self.get_valid_test_suite(
+                        toolTwoSuites, i*4, i*4+3)
                     if (test_suite_tool_two != None):
 
                         if (isinstance(test_suite_tool_two, list)):
@@ -56,30 +57,41 @@ class Coverage_Report(Setup_tool):
 
                         #self.test_suite = self.get_new_suite(test_suite_tool_two[2], test_suite_tool_two[7])
                         dadosParaGravacaoRandoopY = self.retornaDadosParaAnalise(evo, test_suite_path_two, test_suite_commit, jacoco,
-                                                                                 scenario.merge_scenario.sut_class,
-                                                                                 listaPacoteMetodoClasse)
+                                                                                 list(input.targets.keys())[0],
+                                                                                 listaPacoteMetodoClasse, input.targets)
 
                         evo.output_coverage_metric.write_output_line(commitMerge, test_suite_commit, projectName, test_suite_path_one, test_suite_path_two, dadosParaGravacaoRandoopX, dadosParaGravacaoRandoopY, listaPartesBasicasReport,
-                                              listaCoberturaProjeto, listaCoberturaClasse, listaCoberturaMetodo, scenario.merge_scenario.sut_class,
-                                              listaPacoteMetodoClasse[0], jar_type)
+                                                                     listaCoberturaProjeto, listaCoberturaClasse, listaCoberturaMetodo, list(input.targets.keys())[0],
+                                                                     listaPacoteMetodoClasse[0], jar_type)
 
                 if (isinstance(toolOneSuites, list) == False):
-                    break;
+                    break
         except Exception as e:
             print(e)
+
+    def _decomposeTarget(self, targets: "dict[str,list[str]]"):
+        fqcn = list(targets.keys())[0]
+        class_name = fqcn[fqcn.rfind('.') + 1:]
+
+        full_method_signature: str = targets[fqcn][0]
+        method_name = full_method_signature[:full_method_signature.rfind('(')]
+
+        package = fqcn[:fqcn.rfind('.')]
+
+        return method_name, class_name, package
 
     def get_valid_test_suite(self, toolSuites, first_entry, last_entry):
         if(isinstance(toolSuites, list) == False):
             if (os.path.isdir(toolSuites+"/classes")):
                 return toolSuites
         else:
-            for i in range (first_entry, last_entry):
+            for i in range(first_entry, last_entry):
                 if (len(toolSuites) > first_entry and toolSuites[i] != None and toolSuites[i][2] != None and os.path.isdir(toolSuites[i][2]+"/classes")):
                     return toolSuites[i]
 
         return None
 
-    def retornaDadosParaAnalise(self, evo, path_suite, suite_merge, jacoco, classeTarget, listaPacoteMetodoClasse):
+    def retornaDadosParaAnalise(self, evo, path_suite, suite_merge, jacoco, classeTarget, listaPacoteMetodoClasse, targets: "dict[str, list[str]]"):
         global tagAClasseTarget
         global tagSpanMetodoTarget
 
@@ -89,9 +101,11 @@ class Coverage_Report(Setup_tool):
             ":")  # Melhoria poderia ser feita removendo caractere do final da lista caso ele exista.
         listaJarInstrumentados = ""
 
-        for j in range(len(listaJar) - 1):  # -1 pois existe um ultimo : ao final do evo.project_dep.classes_dir
+        # -1 pois existe um ultimo : ao final do evo.project_dep.classes_dir
+        for j in range(len(listaJar) - 1):
             jacoco.execInstrumentJar(listaJar[j], path_suite)
-            nomeJarInstrumentado = listaJar[j].split("/")  # recupera o nome do jar
+            nomeJarInstrumentado = listaJar[j].split(
+                "/")  # recupera o nome do jar
             listaJarInstrumentados = listaJarInstrumentados + path_suite + "/" + nomeJarInstrumentado[len(
                 nomeJarInstrumentado) - 1] + ":"  # nome do jar fica na ultima posicao da lista, : sao colocados para separar os jars
 
@@ -102,10 +116,11 @@ class Coverage_Report(Setup_tool):
         #Importante mencionar, que seria necessário criar um objeto do tipo Suite...
         self.test_suite = self.get_new_suite(path_suite)
 
-        self.run_test_suite(listaJarInstrumentados, evo.project_dep.sut_class, listaJarInstrumentados,
-                            evo.project_dep)
+        self.run_test_suite(listaJarInstrumentados, targets,
+                            listaJarInstrumentados, evo.project_dep)
 
-        listaJar = list(filter(lambda x: x != '', listaJar))  # filtra registros vazios da lista
+        # filtra registros vazios da lista
+        listaJar = list(filter(lambda x: x != '', listaJar))
 
         print("Gerando report em html")
         jacoco.generateReportHtml(path_suite, listaJar, classeTarget)
@@ -114,58 +129,17 @@ class Coverage_Report(Setup_tool):
         dadosReportProjeto = self.reportProjetoCompleto(path_suite)
 
         print("Gerando analise da classe target")
-        dadosReportClasseTarget = self.reportClasseTarget(path_suite, listaPacoteMetodoClasse)
+        dadosReportClasseTarget = self.reportClasseTarget(
+            path_suite, listaPacoteMetodoClasse)
 
         print("Gerando analise do metodo target")
         if ("(" in listaPacoteMetodoClasse[0]) & (")" in listaPacoteMetodoClasse[0]):
-            dadosReportMetodoTarget = self.reportMetodoTarget(path_suite, listaPacoteMetodoClasse)
+            dadosReportMetodoTarget = self.reportMetodoTarget(
+                path_suite, listaPacoteMetodoClasse)
         else:
             dadosReportMetodoTarget = [False]
 
         return [dadosReportProjeto, dadosReportClasseTarget, dadosReportMetodoTarget]
-
-    # recupera pacote, nome da classe ou metodo target do teste
-    def recuperaClassePacoteMetodo(self, pathMetodo, pathClasse):
-        listaPacoteClasse = pathClasse.split(".")
-        nomeClasse = listaPacoteClasse[len(listaPacoteClasse) - 1] # ultima posicao
-        listaPacoteClasse.remove(nomeClasse)
-        pacote = ".".join(listaPacoteClasse)
-        nomeMetodo = pathMetodo[len(pathClasse) + 1:len(pathMetodo)]
-        nomeMetodo = self.adjust_on_method_name(nomeMetodo)
-        #nomeClasse = nomeClasse.replace("$",".")
-        print("Metodo target: " + nomeMetodo)
-        print("Classe target: " + nomeClasse)
-        return [nomeMetodo, nomeClasse, pacote]
-
-    # Ajusta nome do metodo removendo pacote do parametro dentro do metodo
-    # Ex : getSchemaFromAnnotation(io.swagger.oas.annotations.media.Schema) ->  getSchemaFromAnnotation(Schema)
-    def adjust_on_method_name(self, method_name):
-        if ("(" in method_name) & (")" in method_name) & ("." in method_name):
-            print("Required Adjust on Target Method Name")
-            first_parenthesis = method_name.find("(")
-            last_parenthesis = method_name.find(")")
-            parameters = self.adjust_on_parameters(method_name[first_parenthesis:last_parenthesis])
-            method_name = method_name[0:first_parenthesis + 1] + parameters + method_name[last_parenthesis] #")"# contatena por exemplo getSchemaFromAnnotation( + Schema)
-        return method_name
-
-    def adjust_on_parameters(self, parameters):
-        parameters_list = parameters.split(",")
-        adjusted_parameters = []
-        for item in range (len(parameters_list)):
-            if "." in parameters_list[item]:
-                posicaoUltimoPonto = parameters_list[item].rindex(".")
-                parameters_list[item] = parameters_list[item][posicaoUltimoPonto + 1:len(parameters_list[item])].replace("$", ".")
-            else:
-                parameters_list[item] = parameters_list[item][1:]
-            adjusted_parameters.append(parameters_list[item])
-
-        parameters = ""
-        for item in range(len(adjusted_parameters)):
-            parameters += adjusted_parameters[item]
-            if (item < len(adjusted_parameters)-1):
-                parameters += ", "
-
-        return parameters
 
     def reportProjetoCompleto(self, path_suite):
         reportHtml = codecs.open(path_suite + "/report/index.html", 'r')

--- a/nimrod/report_metrics/coverage/coverage_report.py
+++ b/nimrod/report_metrics/coverage/coverage_report.py
@@ -69,6 +69,8 @@ class Coverage_Report(Setup_tool):
         except Exception as e:
             print(e)
 
+    # Currently, this method takes the first target (First method of the first class) and returns it as tuple containing the method name, class name and the package of the class.
+    # Future versions of SMAT will involve producing coverage reports for all the targets provided in the input.
     def _decomposeTarget(self, targets: "dict[str,list[str]]"):
         fqcn = list(targets.keys())[0]
         class_name = fqcn[fqcn.rfind('.') + 1:]

--- a/nimrod/setup_tools/evosuite_setup.py
+++ b/nimrod/setup_tools/evosuite_setup.py
@@ -10,7 +10,7 @@ class Evosuite_setup(Setup_tool):
             java=project_dep.java,
             classpath=project_dep.parentReg,
             tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() +
-            '/' + input.scenario_commits.ancestor,
+            '/' + input.scenario_commits.merge,
             sut_class=project_dep.sut_class,
             sut_classes=project_dep.sut_classes,
             sut_method=project_dep.sut_method,

--- a/nimrod/setup_tools/evosuite_setup.py
+++ b/nimrod/setup_tools/evosuite_setup.py
@@ -1,22 +1,22 @@
+from nimrod.project_info.merge_scenario import MergeScenario
 from nimrod.setup_tools.setup_tool import Setup_tool
 from nimrod.tools.evosuite import Evosuite
-from nimrod.tools.safira import Safira
 
 
 class Evosuite_setup(Setup_tool):
-
-    def generate_test_suite(self, scenario, project_dep):
+    def generate_test_suite(self, scenario: MergeScenario, project_dep):
         evosuite = Evosuite(
             java=project_dep.java,
             classpath=project_dep.parentReg,
-            tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() + '/' + scenario.merge_scenario.get_merge_hash(),
+            tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() +
+            '/' + scenario.merge_scenario.get_merge_hash(),
             sut_class=project_dep.sut_class,
             sut_classes=project_dep.sut_classes,
             sut_method=project_dep.sut_method,
+            scenario=scenario,
             params=self.tool_parameters
         )
-        safira = Safira(java=project_dep.java, classes_dir=project_dep.parentReg,
-                        mutant_dir=project_dep.baseDir)
-        self.test_suite = evosuite.generate_with_impact_analysis(safira, False)
+
+        self.test_suite = evosuite.generate()
 
         return self.test_suite

--- a/nimrod/setup_tools/evosuite_setup.py
+++ b/nimrod/setup_tools/evosuite_setup.py
@@ -1,20 +1,22 @@
+from nimrod.input_parsing.smat_input import SmatInput
 from nimrod.project_info.merge_scenario import MergeScenario
 from nimrod.setup_tools.setup_tool import Setup_tool
 from nimrod.tools.evosuite import Evosuite
 
 
 class Evosuite_setup(Setup_tool):
-    def generate_test_suite(self, scenario: MergeScenario, project_dep):
+    def generate_test_suite(self, scenario: MergeScenario, project_dep, input: SmatInput = None):
         evosuite = Evosuite(
             java=project_dep.java,
             classpath=project_dep.parentReg,
             tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() +
-            '/' + scenario.merge_scenario.get_merge_hash(),
+            '/' + input.scenario_commits.ancestor,
             sut_class=project_dep.sut_class,
             sut_classes=project_dep.sut_classes,
             sut_method=project_dep.sut_method,
             scenario=scenario,
-            params=self.tool_parameters
+            params=self.tool_parameters,
+            input=input
         )
 
         self.test_suite = evosuite.generate()

--- a/nimrod/setup_tools/randoop_modified_setup.py
+++ b/nimrod/setup_tools/randoop_modified_setup.py
@@ -1,24 +1,23 @@
+from nimrod.input_parsing.smat_input import SmatInput
 from nimrod.setup_tools.setup_tool import Setup_tool
 from nimrod.tools.randoop_modified import Randoop_Modified
-from nimrod.tools.safira import Safira
 
 
 class Randoop_Modified_setup(Setup_tool):
 
-    def generate_test_suite(self, scenario, project_dep):
+    def generate_test_suite(self, scenario, project_dep, input: SmatInput):
         randoop = Randoop_Modified(
             java=project_dep.java,
             classpath=project_dep.parentReg,
-            tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() + '/' + scenario.merge_scenario.get_merge_hash(),
+            tests_src=project_dep.tests_dst + '/' +
+            project_dep.project.get_project_name() + '/' + input.scenario_commits.ancestor,
             sut_class=project_dep.sut_class,
             sut_classes=project_dep.sut_classes,
             sut_method=project_dep.sut_method,
-            params=self.tool_parameters
+            params=self.tool_parameters,
+            scenario=scenario,
+            input=input
         )
-        safira = Safira(java=project_dep.java, classes_dir=project_dep.parentReg, mutant_dir=project_dep.baseDir)
-        try:
-            self.test_suite = randoop.generate_with_impact_analysis(safira, True)
-        except Exception as e:
-            print(e)
-            self.test_suite = randoop.generate_with_impact_analysis(safira, False)
+        self.test_suite = randoop.generate_with_impact_analysis()
+
         return self.test_suite

--- a/nimrod/setup_tools/randoop_modified_setup.py
+++ b/nimrod/setup_tools/randoop_modified_setup.py
@@ -10,7 +10,7 @@ class Randoop_Modified_setup(Setup_tool):
             java=project_dep.java,
             classpath=project_dep.parentReg,
             tests_src=project_dep.tests_dst + '/' +
-            project_dep.project.get_project_name() + '/' + input.scenario_commits.ancestor,
+            project_dep.project.get_project_name() + '/' + input.scenario_commits.merge,
             sut_class=project_dep.sut_class,
             sut_classes=project_dep.sut_classes,
             sut_method=project_dep.sut_method,

--- a/nimrod/setup_tools/randoop_setup.py
+++ b/nimrod/setup_tools/randoop_setup.py
@@ -10,7 +10,7 @@ class Randoop_setup(Setup_tool):
             java=project_dep.java,
             classpath=project_dep.parentReg,
             tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() +
-            '/' + input.scenario_commits.ancestor,
+            '/' + input.scenario_commits.merge,
             sut_class=project_dep.sut_class,
             sut_classes=project_dep.sut_classes,
             sut_method=project_dep.sut_method,

--- a/nimrod/setup_tools/randoop_setup.py
+++ b/nimrod/setup_tools/randoop_setup.py
@@ -1,20 +1,22 @@
+from nimrod.input_parsing.smat_input import SmatInput
 from nimrod.setup_tools.setup_tool import Setup_tool
 from nimrod.tools.randoop import Randoop
 
 
 class Randoop_setup(Setup_tool):
 
-    def generate_test_suite(self, scenario, project_dep):
+    def generate_test_suite(self, scenario, project_dep, input: SmatInput):
         randoop = Randoop(
             java=project_dep.java,
             classpath=project_dep.parentReg,
             tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() +
-            '/' + scenario.merge_scenario.get_merge_hash(),
+            '/' + input.scenario_commits.ancestor,
             sut_class=project_dep.sut_class,
             sut_classes=project_dep.sut_classes,
             sut_method=project_dep.sut_method,
             params=self.tool_parameters,
-            scenario=scenario
+            scenario=scenario,
+            input=input
         )
         self.test_suite = randoop.generate_with_impact_analysis()
         return self.test_suite

--- a/nimrod/setup_tools/randoop_setup.py
+++ b/nimrod/setup_tools/randoop_setup.py
@@ -1,7 +1,5 @@
 from nimrod.setup_tools.setup_tool import Setup_tool
 from nimrod.tools.randoop import Randoop
-from nimrod.tools.randoopY import RandoopY
-from nimrod.tools.safira import Safira
 
 
 class Randoop_setup(Setup_tool):
@@ -10,16 +8,13 @@ class Randoop_setup(Setup_tool):
         randoop = Randoop(
             java=project_dep.java,
             classpath=project_dep.parentReg,
-            tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() + '/' + scenario.merge_scenario.get_merge_hash(),
+            tests_src=project_dep.tests_dst + '/' + project_dep.project.get_project_name() +
+            '/' + scenario.merge_scenario.get_merge_hash(),
             sut_class=project_dep.sut_class,
             sut_classes=project_dep.sut_classes,
             sut_method=project_dep.sut_method,
-            params=self.tool_parameters
+            params=self.tool_parameters,
+            scenario=scenario
         )
-        safira = Safira(java=project_dep.java, classes_dir=project_dep.parentReg, mutant_dir=project_dep.baseDir)
-        try:
-            self.test_suite = randoop.generate_with_impact_analysis(safira, True)
-        except Exception as e:
-            print(e)
-            self.test_suite = randoop.generate_with_impact_analysis(safira, False)
+        self.test_suite = randoop.generate_with_impact_analysis()
         return self.test_suite

--- a/nimrod/setup_tools/setup_tool.py
+++ b/nimrod/setup_tools/setup_tool.py
@@ -40,12 +40,12 @@ class Setup_tool(ABC):
         jarBase = input.scenario_jars.base
         jarParentLeft = input.scenario_jars.left
         jarParentRight = input.scenario_jars.right
-        jarMerge = input.scenario_jars.ancestor
+        jarMerge = input.scenario_jars.merge
 
         commitBaseSha = input.scenario_commits.base
         commitParentLeft = input.scenario_commits.left
         commitParentRight = input.scenario_commits.right
-        commitMergeSha = input.scenario_commits.ancestor
+        commitMergeSha = input.scenario_commits.merge
 
         try:
             self.setup_for_full_merge_scenario(evo, scenario, jarBase, jarParentLeft, jarParentRight, jarMerge)

--- a/nimrod/setup_tools/setup_tool.py
+++ b/nimrod/setup_tools/setup_tool.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from ast import Suite
+import logging
 from nimrod.project_info.commit import Commit
 from nimrod.project_info.merge_scenario import MergeScenario
 
@@ -84,8 +85,11 @@ class Setup_tool(ABC):
         test_result_other_parent = set()
         test_result_merge = set()
         try:
+            logging.info("Starting test suite generation with %s tool", tool)
             path_suite = self.generate_test_suite(scenario, evo.project_dep)
+            logging.info("Finished test suite generation with %s tool", tool)
 
+            logging.info("Starting test suite execution for commit %s", scenario.merge_scenario.base_hash)
             test_result_base = self.run_test_suite(evo.project_dep.parentReg, scenario.merge_scenario.targets,
                                                    evo.project_dep.baseDir, evo.project_dep)
             test_result_parent_test_suite = self.run_test_suite(evo.project_dep.parentReg, scenario.merge_scenario.targets,

--- a/nimrod/setup_tools/setup_tool.py
+++ b/nimrod/setup_tools/setup_tool.py
@@ -91,7 +91,8 @@ class Setup_tool(ABC):
                                                            evo.project_dep.parentNotReg, evo.project_dep)
             test_result_merge = self.run_test_suite(evo.project_dep.parentReg, evo.project_dep.sut_class,
                                                     evo.project_dep.mergeDir, evo.project_dep)
-        except:
+        except Exception as exception:
+            print(exception)
             print("Some project versions could not be evaluated")
             conflict_info.append(["NONE", set(), "NO-INFORMATION", commitBaseSha, commitParentTestSuite, commitMergeSha,
                                     tool])

--- a/nimrod/tests/env-config.json
+++ b/nimrod/tests/env-config.json
@@ -4,8 +4,8 @@
 
   "repo_dir": "",
   "projects_folder": "",
-  "path_hash_csv" : "",
+  "input_path": "",
   "tests_dst": "",
-  "path_output_csv": ""
-
+  "path_output_csv": "",
+  "logger_level": "DEBUG"
 }

--- a/nimrod/tests/tools/test_evosuite.py
+++ b/nimrod/tests/tools/test_evosuite.py
@@ -2,6 +2,8 @@ from unittest import TestCase
 
 import os
 import shutil
+from nimrod.input_parsing.smat_input import SmatInput
+from nimrod.project_info.merge_scenario import MergeScenario
 
 from nimrod.tests.utils import get_config
 from nimrod.tests.utils import calculator_project_dir
@@ -35,7 +37,8 @@ class TestEvosuite(TestCase):
             classpath=os.path.join(calculator_target_dir(), 'classes'),
             tests_src=tests_src,
             sut_class='br.ufal.ic.easy.operations.Sum',
-            params=['-Dsearch_budget=1']
+            params=['-Dsearch_budget=1'],
+            input=SmatInput(targets={'br.ufal.ic.easy.operations.Sum': []})
         )
 
         (suite_name, suite_dir, suite_classes_dir,
@@ -59,7 +62,8 @@ class TestEvosuite(TestCase):
             classpath=os.path.join(calculator_target_dir(), 'classes'),
             tests_src=tests_src,
             sut_class='br.ufal.ic.easy.operations.Sum',
-            params=['-Dsearch_budget=1']
+            params=['-Dsearch_budget=1'],
+            input=SmatInput(targets={'br.ufal.ic.easy.operations.Sum': []})
         )
 
         mutants = MuJava(java=self.java,

--- a/nimrod/tests/tools/test_evosuite.py
+++ b/nimrod/tests/tools/test_evosuite.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import os
 import shutil
-from nimrod.input_parsing.smat_input import SmatInput
+from nimrod.input_parsing.smat_input import ScenarioInformation, SmatInput
 from nimrod.project_info.merge_scenario import MergeScenario
 
 from nimrod.tests.utils import get_config
@@ -28,6 +28,18 @@ class TestEvosuite(TestCase):
 
         self.maven.compile(calculator_project_dir(), 10)
 
+    def _get_testing_input(self) -> SmatInput:
+        return SmatInput(
+            project_name="testing-project",
+            run_analysis=True,
+            scenario_commits=ScenarioInformation(
+                base="abcdef", left="fedcba", right="defabc", merge="fedcba"),
+            scenario_jars=ScenarioInformation(
+                base="abcdef", left="fedcba", right="defabc", merge="fedcba"),
+            jar_type="transformation",
+            targets={'br.ufal.ic.easy.operations.Sum': []}
+        )
+
     def test_generate(self):
 
         tests_src = os.path.join(calculator_project_dir(), 'evosuite')
@@ -36,9 +48,8 @@ class TestEvosuite(TestCase):
             java=self.java,
             classpath=os.path.join(calculator_target_dir(), 'classes'),
             tests_src=tests_src,
-            sut_class='br.ufal.ic.easy.operations.Sum',
             params=['-Dsearch_budget=1'],
-            input=SmatInput(targets={'br.ufal.ic.easy.operations.Sum': []})
+            input=self._get_testing_input()
         )
 
         (suite_name, suite_dir, suite_classes_dir,
@@ -49,7 +60,7 @@ class TestEvosuite(TestCase):
 
         self.assertTrue(len(get_java_files(suite_dir)) > 1)
         self.assertTrue(len(get_class_files(suite_classes_dir)) > 1)
-        self.assertEquals(1, len(suite_classes))
+        self.assertEqual(1, len(suite_classes))
 
         shutil.rmtree(tests_src)
 
@@ -61,9 +72,8 @@ class TestEvosuite(TestCase):
             java=self.java,
             classpath=os.path.join(calculator_target_dir(), 'classes'),
             tests_src=tests_src,
-            sut_class='br.ufal.ic.easy.operations.Sum',
             params=['-Dsearch_budget=1'],
-            input=SmatInput(targets={'br.ufal.ic.easy.operations.Sum': []})
+            input=self._get_testing_input()
         )
 
         mutants = MuJava(java=self.java,
@@ -77,7 +87,7 @@ class TestEvosuite(TestCase):
 
         self.assertTrue(len(get_java_files(suite_dir)) > 1)
         self.assertTrue(len(get_class_files(suite_classes_dir)) > 1)
-        self.assertEquals(1, len(suite_classes))
+        self.assertEqual(1, len(suite_classes))
 
         shutil.rmtree(tests_src)
 

--- a/nimrod/tests/tools/test_jacoco.py
+++ b/nimrod/tests/tools/test_jacoco.py
@@ -40,15 +40,3 @@ class TestJacoco(TestCase):
         csvFile = "/home/vinicius/Documentos/UFPE/TCC/Resultados/CloudSlang/cloudslang-all/dest/report.csv"
 
         self.jacoco.generateReport(jacocoExecDir, classFile, csvFile)
-
-    def test_method_adjust_without_primitive_types(self):
-        coverage_report = Coverage_Report()
-        self.assertEqual("outerHtmlHead(StringBuilder, OutputSettings)", coverage_report.adjust_on_method_name("outerHtmlHead(java.lang.StringBuilder, org.jsoup.nodes.OutputSettings)"))
-
-    def test_method_adjust_with_inner_class_types(self):
-        coverage_report = Coverage_Report()
-        self.assertEqual("outerHtmlHead(StringBuilder, int, Document.OutputSettings)", coverage_report.adjust_on_method_name("outerHtmlHead(java.lang.StringBuilder, int, org.jsoup.nodes.Document$OutputSettings)"))
-
-    def test_method_adjust_with_primitive_types(self):
-        coverage_report = Coverage_Report()
-        self.assertEqual("outerHtmlHead(StringBuilder, int, String, OutputSettings)", coverage_report.adjust_on_method_name("outerHtmlHead(java.lang.StringBuilder, int, String, org.jsoup.nodes.OutputSettings)"))

--- a/nimrod/tests/tools/test_randoop.py
+++ b/nimrod/tests/tools/test_randoop.py
@@ -49,38 +49,9 @@ class TestRandoop(TestCase):
 
         self.assertTrue(len(get_java_files(suite_dir)) > 1)
         self.assertTrue(len(get_class_files(suite_classes_dir)) > 1)
-        self.assertEquals(2, len(suite_classes))
+        self.assertEqual(2, len(suite_classes))
 
         # shutil.rmtree(tests_src)
-
-    def test_generate_with_impact_analysis(self):
-        tests_src = os.path.join(calculator_project_dir(), 'randoop')
-        classes_dir = os.path.join(calculator_target_dir(), 'classes')
-
-        randoop = Randoop(
-            java=self.java,
-            classpath=classes_dir,
-            tests_src=tests_src,
-            sut_class='br.ufal.ic.easy.operations.Sum',
-            sut_classes=['br.ufal.ic.easy.operations.Sum']
-        )
-        randoop.parameters = ['--time-limit=1',
-                              '--testclass=br.ufal.ic.easy.operations.Sum']
-
-        safira = Safira(self.java, classes_dir,
-                        calculator_src_aor_1())
-
-        (suite_name, suite_dir, suite_classes_dir,
-         suite_classes) = randoop.generate_with_impact_analysis(safira)
-
-        self.assertTrue(suite_name.startswith('randoop'))
-        self.assertTrue(os.path.exists(suite_dir))
-
-        self.assertTrue(len(get_java_files(suite_dir)) > 1)
-        self.assertTrue(len(get_class_files(suite_classes_dir)) > 1)
-        self.assertEquals(2, len(suite_classes))
-
-        shutil.rmtree(tests_src)
 
     def tearDown(self):
         calculator_clean_project()

--- a/nimrod/tests/utils.py
+++ b/nimrod/tests/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import json
 import shutil
@@ -5,7 +6,7 @@ import shutil
 PATH = os.path.dirname(os.path.abspath(__file__))
 
 
-def get_config():
+def get_config() -> "dict[str, str]":
     with open(os.path.join(PATH, os.sep.join(['env-config.json'])), 'r') as j:
         j = json.loads(j.read())
 
@@ -68,3 +69,10 @@ def calculator_src_aor_1():
 def calculator_sum_aor_1():
     return os.path.join(calculator_src_aor_1(), 'br', 'ufal', 'ic', 'easy',
                         'operations', 'Sum.java')
+
+
+def setup_logging():
+    config = get_config()
+    config_level = config.get('logger_level')
+    level = logging._nameToLevel[config_level] if config_level else logging.INFO
+    logging.basicConfig(level=level)

--- a/nimrod/tools/evosuite.py
+++ b/nimrod/tools/evosuite.py
@@ -12,7 +12,7 @@ class Evosuite(SuiteGenerator):
         return "evosuite"
 
     def _exec_tool(self):
-        for class_name, methods in self.scenario.merge_scenario.targets.items():
+        for class_name, methods in self.input.targets.items():
             params = [
                 '-jar', EVOSUITE,
                 '-projectCP', self.classpath,

--- a/nimrod/tools/evosuite.py
+++ b/nimrod/tools/evosuite.py
@@ -17,14 +17,14 @@ class Evosuite(SuiteGenerator):
                 '-jar', EVOSUITE,
                 '-projectCP', self.classpath,
                 '-class', class_name,
-                '-Dtimeout', '1000',
+                '-Dtimeout', '40',
                 '-Dassertion_strategy=all',
                 '-Dp_reflection_on_private=0',
                 '-Dreflection_start_percent=0',
                 '-Dp_functional_mocking=0',
                 '-Dfunctional_mocking_percent=0',
                 '-Dminimize=false',
-                '-Dsearch_budget=300',
+                '-Dsearch_budget=10',
                 '-Djunit_check=false',
                 '-Dinline=false',
                 '-DOUTPUT_DIR=' + self.suite_dir,
@@ -74,7 +74,7 @@ class Evosuite(SuiteGenerator):
                 '-Dregressioncp=' + mutants_classpath,
                 '-class', class_name,
                 '-DOUTPUT_DIR=' + self.suite_dir,
-                '-Dsearch_budget=300',
+                '-Dsearch_budget=10',
             ]
 
             if len(methods) > 0:

--- a/nimrod/tools/evosuite.py
+++ b/nimrod/tools/evosuite.py
@@ -17,14 +17,14 @@ class Evosuite(SuiteGenerator):
                 '-jar', EVOSUITE,
                 '-projectCP', self.classpath,
                 '-class', class_name,
-                '-Dtimeout', '10000',
+                '-Dtimeout', '1000',
                 '-Dassertion_strategy=all',
                 '-Dp_reflection_on_private=0',
                 '-Dreflection_start_percent=0',
                 '-Dp_functional_mocking=0',
                 '-Dfunctional_mocking_percent=0',
                 '-Dminimize=false',
-                '-Dsearch_budget=30',
+                '-Dsearch_budget=300',
                 '-Djunit_check=false',
                 '-Dinline=false',
                 '-DOUTPUT_DIR=' + self.suite_dir,
@@ -66,18 +66,23 @@ class Evosuite(SuiteGenerator):
         return ordered_files
 
     def _exec_differential(self, mutants_classpath):
-        params = [
-            '-jar', EVOSUITE,
-            '-regressionSuite',
-            '-projectCP', self.classpath,
-            '-Dregressioncp=' + mutants_classpath,
-            '-class', self.sut_class,
-            '-DOUTPUT_DIR=' + self.suite_dir
-        ]
+        for class_name, methods in self.input.targets.items():
+            params = [
+                '-jar', EVOSUITE,
+                '-regressionSuite',
+                '-projectCP', self.classpath,
+                '-Dregressioncp=' + mutants_classpath,
+                '-class', class_name,
+                '-DOUTPUT_DIR=' + self.suite_dir,
+                '-Dsearch_budget=300',
+            ]
 
-        params += self.parameters
+            if len(methods) > 0:
+                params.append('-Dtarget_method_list="' +
+                              self.create_method_list(methods) + '"')
 
-        return self._exec(*tuple(params))
+            params += self.parameters
+            self._exec(*tuple(params))
 
     def generate_differential(self, mutant_classpath, make_dir=True):
         if make_dir:

--- a/nimrod/tools/java.py
+++ b/nimrod/tools/java.py
@@ -94,7 +94,7 @@ class Java:
             logging.error(e)
             raise e
         except FileNotFoundError as e:
-            logging.error('[ERROR] {0}: not found.'.format(program), file=sys.stderr)
+            logging.error('[ERROR] {0}: not found.'.format(program))
             raise e
 
     def get_env(self, variables=None):

--- a/nimrod/tools/java.py
+++ b/nimrod/tools/java.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import subprocess
@@ -77,23 +78,23 @@ class Java:
         try:
             command = [program] + list(args)
 
-            print(command)
+            logging.debug(command)
 
             return subprocess.check_output(command, cwd=cwd, env=env,
                                            timeout=timeout,
                                            stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print(e)
+            logging.error(e)
             raise e
         except RuntimeError as e:
-            print(e)
+            logging.error(e)
             RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
             raise e
         except subprocess.TimeoutExpired as e:
-            print(e)
+            logging.error(e)
             raise e
         except FileNotFoundError as e:
-            print('[ERROR] {0}: not found.'.format(program), file=sys.stderr)
+            logging.error('[ERROR] {0}: not found.'.format(program), file=sys.stderr)
             raise e
 
     def get_env(self, variables=None):

--- a/nimrod/tools/randoop.py
+++ b/nimrod/tools/randoop.py
@@ -53,7 +53,7 @@ class Randoop(SuiteGenerator):
         filename = os.path.join(self.suite_dir, filename)
 
         with open(filename, 'w') as f:
-            fqcns = self.scenario.merge_scenario.targets.keys()
+            fqcns = self.input.targets.keys()
             [f.write(fqcn.replace(" ", "") + "\n") for fqcn in fqcns]
             f.close()
 
@@ -63,7 +63,7 @@ class Randoop(SuiteGenerator):
         filename = os.path.join(self.suite_dir, filename)
 
         with open(filename, 'w') as f:
-            for fqcn, methods in self.scenario.merge_scenario.targets.items():
+            for fqcn, methods in self.input.targets.items():
                 for method in methods:
                     method_signature = fqcn + "." + method
                     f.write(method_signature)

--- a/nimrod/tools/randoop.py
+++ b/nimrod/tools/randoop.py
@@ -1,12 +1,8 @@
-from nimrod.tools.suite_generator import SuiteGenerator
-
 import os
-import random
 
-from nimrod.utils import generate_classpath
 from nimrod.tools.bin import RANDOOP
-from nimrod.tools.bin import MOD_RANDOOP
-
+from nimrod.tools.suite_generator import Suite, SuiteGenerator
+from nimrod.utils import generate_classpath
 
 METHOD_LIST_FILENAME = 'methods_to_test.txt'
 TARGET_CLASS_LIST_FILENAME = 'classes_to_test.txt'
@@ -34,15 +30,10 @@ class Randoop(SuiteGenerator):
     def _test_classes(self):
         return ['RegressionTest', 'ErrorTest']
 
-    def generate_with_impact_analysis(self, impact_analysis, method_analysis=False):
-        method_list = ""
+    def generate_with_impact_analysis(self) -> Suite:
         self._make_src_dir()
-        impact_analysis_result = impact_analysis.run()
-        class_list = self.create_target_class_list(self.suite_dir)
-        if (method_analysis):
-            method_list = self.create_method_list_for_one_single_method(impact_analysis_result, self.suite_dir)
-        else:
-            method_list = self.create_method_list(impact_analysis_result, self.suite_dir)
+        class_list = self.create_target_classes_list()
+        method_list = self.create_target_methods_list()
 
         if os.path.exists(method_list):
             elem = [x for x in self.parameters if '--methodlist=' in x]
@@ -58,41 +49,23 @@ class Randoop(SuiteGenerator):
 
         return super().generate(make_dir=False)
 
-    
-    def create_target_class_list(self, output_dir,
-                           filename=TARGET_CLASS_LIST_FILENAME):
-        filename = os.path.join(output_dir, filename)
+    def create_target_classes_list(self, filename=TARGET_CLASS_LIST_FILENAME) -> str:
+        filename = os.path.join(self.suite_dir, filename)
 
         with open(filename, 'w') as f:
-            methods = self.sut_classes
-            [f.write(l.replace(" ","") + "\n") for l in methods]
+            fqcns = self.scenario.merge_scenario.targets.keys()
+            [f.write(fqcn.replace(" ", "") + "\n") for fqcn in fqcns]
             f.close()
 
         return filename
 
-    def create_method_list(self, impact_analysis_result, output_dir,
-                           filename=METHOD_LIST_FILENAME):
-        filename = os.path.join(output_dir, filename)
+    def create_target_methods_list(self, filename=METHOD_LIST_FILENAME) -> str:
+        filename = os.path.join(self.suite_dir, filename)
 
         with open(filename, 'w') as f:
-            methods = (impact_analysis_result.constructors
-                       + impact_analysis_result.methods)
-            [f.write(l + '\n') for l in methods]
-            f.close()
-
-        return filename
-
-    def create_method_list_for_one_single_method(self, impact_analysis_result, output_dir,
-                           filename=METHOD_LIST_FILENAME):
-        filename = os.path.join(output_dir, filename)
-
-        with open(filename, 'w') as f:
-            method_name = self.sut_method
-            try:
-                method_name = [e+")" for e in self.sut_method.split(")") if e][0]
-            except Exception as e:
-                print(e)
-            f.write(method_name)
-            f.close()
+            for fqcn, methods in self.scenario.merge_scenario.targets.items():
+                for method in methods:
+                    method_signature = fqcn + "." + method
+                    f.write(method_signature)
 
         return filename

--- a/nimrod/tools/randoopY.py
+++ b/nimrod/tools/randoopY.py
@@ -12,7 +12,7 @@ class RandoopY(Randoop):
             'randoop.main.Main',
             'gentests',
             '--randomseed=10',
-            '--time-limit=10',
+            '--time-limit=300',
             '--testclass=' + self.sut_class,
             '--junit-output-dir=' + self.suite_dir
         ]

--- a/nimrod/tools/randoopY.py
+++ b/nimrod/tools/randoopY.py
@@ -12,7 +12,7 @@ class RandoopY(Randoop):
             'randoop.main.Main',
             'gentests',
             '--randomseed=10',
-            '--time-limit=300',
+            '--time-limit=10',
             '--testclass=' + self.sut_class,
             '--junit-output-dir=' + self.suite_dir
         ]

--- a/nimrod/tools/randoop_modified.py
+++ b/nimrod/tools/randoop_modified.py
@@ -21,7 +21,7 @@ class Randoop_Modified(SuiteGenerator):
             'randoop.main.Main',
             'gentests',
             '--randomseed=10',
-            '--time-limit=300',
+            '--time-limit=10',
             '--junit-output-dir=' + self.suite_dir
         ]
 

--- a/nimrod/tools/randoop_modified.py
+++ b/nimrod/tools/randoop_modified.py
@@ -32,15 +32,10 @@ class Randoop_Modified(SuiteGenerator):
     def _test_classes(self):
         return ['RegressionTest', 'ErrorTest']
 
-    def generate_with_impact_analysis(self, impact_analysis, method_analysis):
-        method_list = ""
+    def generate_with_impact_analysis(self):
         self._make_src_dir()
-        impact_analysis_result = impact_analysis.run()
-        class_list = self.create_target_class_list(self.suite_dir)
-        if (method_analysis):
-            method_list = self.create_method_list_for_one_single_method(impact_analysis_result, self.suite_dir)
-        else:
-            method_list = self.create_method_list(impact_analysis_result, self.suite_dir)
+        class_list = self.create_target_classes_list()
+        method_list = self.create_target_methods_list()
 
         if os.path.exists(method_list):
             elem = [x for x in self.parameters if '--methodlist=' in x]
@@ -56,41 +51,23 @@ class Randoop_Modified(SuiteGenerator):
 
         return super().generate(make_dir=False)
 
-
-    def create_target_class_list(self, output_dir,
-                                 filename=TARGET_CLASS_LIST_FILENAME):
-        filename = os.path.join(output_dir, filename)
+    def create_target_classes_list(self, filename=TARGET_CLASS_LIST_FILENAME) -> str:
+        filename = os.path.join(self.suite_dir, filename)
 
         with open(filename, 'w') as f:
-            methods = self.sut_classes
-            [f.write(l.replace(" ","") + "\n") for l in methods]
+            fqcns = self.input.targets.keys()
+            [f.write(fqcn.replace(" ", "") + "\n") for fqcn in fqcns]
             f.close()
 
         return filename
 
-    def create_method_list(self, impact_analysis_result, output_dir,
-                           filename=METHOD_LIST_FILENAME):
-        filename = os.path.join(output_dir, filename)
+    def create_target_methods_list(self, filename=METHOD_LIST_FILENAME) -> str:
+        filename = os.path.join(self.suite_dir, filename)
 
         with open(filename, 'w') as f:
-            methods = (impact_analysis_result.constructors
-                       + impact_analysis_result.methods)
-            [f.write(l + '\n') for l in methods]
-            f.close()
-
-        return filename
-
-    def create_method_list_for_one_single_method(self, impact_analysis_result, output_dir,
-                                                 filename=METHOD_LIST_FILENAME):
-        filename = os.path.join(output_dir, filename)
-
-        with open(filename, 'w') as f:
-            method_name = self.sut_method
-            try:
-                method_name = [e+")" for e in self.sut_method.split(")") if e][0]
-            except Exception as e:
-                print(e)
-            f.write(method_name)
-            f.close()
+            for fqcn, methods in self.input.targets.items():
+                for method in methods:
+                    method_signature = fqcn + "." + method
+                    f.write(method_signature)
 
         return filename

--- a/nimrod/tools/randoop_modified.py
+++ b/nimrod/tools/randoop_modified.py
@@ -21,7 +21,7 @@ class Randoop_Modified(SuiteGenerator):
             'randoop.main.Main',
             'gentests',
             '--randomseed=10',
-            '--time-limit=10',
+            '--time-limit=300',
             '--junit-output-dir=' + self.suite_dir
         ]
 

--- a/nimrod/tools/suite_generator.py
+++ b/nimrod/tools/suite_generator.py
@@ -7,6 +7,7 @@ import subprocess
 import threading
 
 from collections import namedtuple
+from nimrod.input_parsing.smat_input import SmatInput
 from nimrod.project_info.merge_scenario import MergeScenario
 
 from nimrod.utils import get_java_files
@@ -24,7 +25,7 @@ Suite = namedtuple('Suite', ['suite_name', 'suite_dir', 'suite_classes_dir',
 
 class SuiteGenerator(ABC):
 
-    def __init__(self, java, classpath, tests_src, sut_class, sut_classes=None, sut_method=None, params=None, scenario: MergeScenario = None):
+    def __init__(self, java, classpath, tests_src, sut_class, sut_classes=None, sut_method=None, params=None, scenario: MergeScenario = None, input: SmatInput = None):
         self.java = java
         self.tests_src = tests_src
         self.classpath = classpath
@@ -36,6 +37,7 @@ class SuiteGenerator(ABC):
         self.suite_classes_dir = None
         self.suite_name = self._set_suite_name()
         self.scenario = scenario
+        self.input = input
 
     @abstractmethod
     def _exec_tool(self):

--- a/nimrod/tools/suite_generator.py
+++ b/nimrod/tools/suite_generator.py
@@ -25,7 +25,7 @@ Suite = namedtuple('Suite', ['suite_name', 'suite_dir', 'suite_classes_dir',
 
 class SuiteGenerator(ABC):
 
-    def __init__(self, java, classpath, tests_src, sut_class, sut_classes=None, sut_method=None, params=None, scenario: MergeScenario = None, input: SmatInput = None):
+    def __init__(self, java, classpath, tests_src, sut_class=None, sut_classes=None, sut_method=None, params=None, scenario: MergeScenario = None, input: SmatInput = None):
         self.java = java
         self.tests_src = tests_src
         self.classpath = classpath

--- a/nimrod/tools/suite_generator.py
+++ b/nimrod/tools/suite_generator.py
@@ -7,6 +7,7 @@ import subprocess
 import threading
 
 from collections import namedtuple
+from nimrod.project_info.merge_scenario import MergeScenario
 
 from nimrod.utils import get_java_files
 from nimrod.utils import generate_classpath
@@ -23,7 +24,7 @@ Suite = namedtuple('Suite', ['suite_name', 'suite_dir', 'suite_classes_dir',
 
 class SuiteGenerator(ABC):
 
-    def __init__(self, java, classpath, tests_src, sut_class, sut_classes=None, sut_method=None, params=None):
+    def __init__(self, java, classpath, tests_src, sut_class, sut_classes=None, sut_method=None, params=None, scenario: MergeScenario = None):
         self.java = java
         self.tests_src = tests_src
         self.classpath = classpath
@@ -34,6 +35,7 @@ class SuiteGenerator(ABC):
         self.suite_dir = None
         self.suite_classes_dir = None
         self.suite_name = self._set_suite_name()
+        self.scenario = scenario
 
     @abstractmethod
     def _exec_tool(self):


### PR DESCRIPTION
This PR introduces a new API for SMAT. The old CSV has been replaced with a JSON input, which allows the user to target multiple classes/methods for suite test generation.

BREAKING CHANGE: The property `path_hash_csv` is now deprecated and the property `input_path` should now be the preferred way. The old CSV input is still accepted by SMAT but can be removed in a future version.

Following, is an example for the new input for SMAT:
```json
[
  {
    "projectName": "spring-boot",
    "runAnalysis": true,
    "scenarioCommits": {
      "base": "7578f2f824aac027529878810b76ee176b39e73a",
      "left": "0d00039ae7d01538de3f813b17d125dc5fdd5706",
      "right": "1c21f54bf91283d70e04c49ea09a4c05a885d7ac",
      "merge": "3eebbe1c8aed529e6903e78476492592ce0b0049"
    },
    "targets": {
      "org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory": [
        "createDeploymentManager(org.springframework.boot.context.embedded.ServletContextInitializer[])"
      ]
    },
    "scenarioJars": {
      "base": "/home/jpedroh/Projetos/cin/testes-smat/spring-boot/7578f2f824aac027529878810b76ee176b39e73a-createDeploymentManager.jar",
      "left": "/home/jpedroh/Projetos/cin/testes-smat/spring-boot/0d00039ae7d01538de3f813b17d125dc5fdd5706-createDeploymentManager.jar",
      "right": "/home/jpedroh/Projetos/cin/testes-smat/spring-boot/1c21f54bf91283d70e04c49ea09a4c05a885d7ac-createDeploymentManager.jar",
      "merge": "/home/jpedroh/Projetos/cin/testes-smat/spring-boot/3eebbe1c8aed529e6903e78476492592ce0b0049-createDeploymentManager.jar"
    },
    "jarType": "transformation"
  }
]
```