### PR TITLE
refactor: move Dynamic Analysis into a separate module.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Lint with mypy
-      run: mypy nimrod/test_suite_generation/ nimrod/test_suites_execution/
+      run: mypy nimrod/test_suite_generation/ nimrod/test_suites_execution/ nimrod/dynamic_analysis/
     - name: Setup Java
       uses: actions/setup-java@v2
       with:

--- a/nimrod/__main__.py
+++ b/nimrod/__main__.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Dict, List
+from nimrod.dynamic_analysis.behavior_change_checker import BehaviorChangeChecker
+from nimrod.dynamic_analysis.criteria.first_semantic_conflict_criteria import FirstSemanticConflictCriteria
+from nimrod.dynamic_analysis.criteria.second_semantic_conflict_criteria import SecondSemanticConflictCriteria
+from nimrod.dynamic_analysis.main import DynamicAnalysis
+from nimrod.input_parsing.smat_input import SmatInput
+from nimrod.smat import SMAT
+from nimrod.test_suite_generation.main import TestSuiteGeneration
+from nimrod.tests.utils import setup_logging, get_config
+from nimrod.test_suite_generation.generators.test_suite_generator import TestSuiteGenerator
+from nimrod.test_suite_generation.generators.randoop_test_suite_generator import RandoopTestSuiteGenerator
+from nimrod.test_suite_generation.generators.evosuite_differential_test_suite_generator import EvosuiteDifferentialTestSuiteGenerator
+from nimrod.test_suite_generation.generators.evosuite_test_suite_generator import EvosuiteTestSuiteGenerator
+from nimrod.test_suites_execution.main import TestSuitesExecution, TestSuiteExecutor
+from nimrod.tools.bin import MOD_RANDOOP, RANDOOP
+from nimrod.tools.java import Java
+from nimrod.input_parsing.input_parser import CsvInputParser, JsonInputParser
+
+
+def get_test_suite_generators(config: Dict[str, str]) -> List[TestSuiteGenerator]:
+  config_generators = config.get(
+      'test_suite_generators', 'randoop,randoop-modified,evosuite,evosuite-differential')
+  generators = list()
+
+  if 'randoop' in config_generators:
+    generators.append(RandoopTestSuiteGenerator(Java(), RANDOOP, "RANDOOP"))
+  if 'randoop-modified' in config_generators:
+    generators.append(RandoopTestSuiteGenerator(
+        Java(), MOD_RANDOOP, "RANDOOP_MODIFIED"))
+  if 'evosuite' in config_generators:
+    generators.append(EvosuiteTestSuiteGenerator(Java()))
+  if 'evosuite-differential' in config_generators:
+    generators.append(EvosuiteDifferentialTestSuiteGenerator(Java()))
+
+  return generators
+
+
+def parse_scenarios_from_input(config: Dict[str, str]) -> List[SmatInput]:
+    if config.get('input_path'):
+        return JsonInputParser().parse_input(config.get('input_path'))
+    elif config.get('path_hash_csv'):
+        logging.WARN(
+            'DEPRECATED: Providing input data with `path_hash_csv` is deprecated and will be removed in future versions of SMAT. Use `input_path` instead.')
+        return CsvInputParser().parse_input(config.get('path_hash_csv'))
+    else:
+        logging.FATAL('Non input file provided')
+        exit(1)
+
+
+def main():
+  setup_logging()
+  config = get_config()
+  test_suite_generators = get_test_suite_generators(config)
+  test_suite_generation = TestSuiteGeneration(test_suite_generators)
+  test_suites_execution = TestSuitesExecution(TestSuiteExecutor(Java()))
+  dynamic_analysis = DynamicAnalysis([
+      FirstSemanticConflictCriteria(),
+      SecondSemanticConflictCriteria()
+  ], BehaviorChangeChecker())
+
+  smat = SMAT(test_suite_generation, test_suites_execution, dynamic_analysis)
+  scenarios = parse_scenarios_from_input(config)
+
+  for scenario in scenarios:
+    smat.run_tool_for_semmantic_conflict_detection(scenario)
+
+
+if __name__ == '__main__':
+  main()

--- a/nimrod/dynamic_analysis/behavior_change.py
+++ b/nimrod/dynamic_analysis/behavior_change.py
@@ -1,0 +1,8 @@
+from typing import Tuple
+from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import TestCaseExecutionInMergeScenario
+
+
+class BehaviorChange:
+    def __init__(self, detected_in: TestCaseExecutionInMergeScenario, between: Tuple[str, str]):
+        self.detected_in = detected_in
+        self.between = between

--- a/nimrod/dynamic_analysis/behavior_change_checker.py
+++ b/nimrod/dynamic_analysis/behavior_change_checker.py
@@ -1,0 +1,10 @@
+from nimrod.test_suites_execution.test_case_result import TestCaseResult
+
+
+class BehaviorChangeChecker:
+    def has_behavior_change_between(self, one: TestCaseResult, two: TestCaseResult) -> bool:
+      if one == TestCaseResult.PASS:
+          return two == TestCaseResult.FAIL
+      elif one == TestCaseResult.FAIL:
+          return two == TestCaseResult.PASS
+      return False

--- a/nimrod/dynamic_analysis/criteria/dynamic_analysis_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/dynamic_analysis_criteria.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import \
+    TestCaseExecutionInMergeScenario
+
+
+class DynamicAnalysisCriteria(ABC):
+  @abstractmethod
+  def is_satisfied_by(self, test_case_execution: TestCaseExecutionInMergeScenario) -> bool:
+    pass

--- a/nimrod/dynamic_analysis/criteria/first_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/first_semantic_conflict_criteria.py
@@ -12,11 +12,13 @@ class FirstSemanticConflictCriteria(DynamicAnalysisCriteria):
         passes_in_base_and_merge_but_fails_in_a_single_parent = \
             test_case_execution.merge == TestCaseResult.PASS \
             and test_case_execution.base == TestCaseResult.PASS \
-            and bool(xor(test_case_execution.left == TestCaseResult.FAIL, test_case_execution.right == TestCaseResult.FAIL))
+            and (test_case_execution.left == TestCaseResult.FAIL
+                 or test_case_execution.right == TestCaseResult.FAIL)
 
         fails_in_base_and_merge_but_passes_in_a_single_parent = \
             test_case_execution.merge == TestCaseResult.FAIL \
             and test_case_execution.base == TestCaseResult.FAIL \
-            and bool(xor(test_case_execution.left == TestCaseResult.PASS, test_case_execution.right == TestCaseResult.PASS))
+            and (test_case_execution.left == TestCaseResult.PASS
+                 or test_case_execution.right == TestCaseResult.PASS)
 
         return passes_in_base_and_merge_but_fails_in_a_single_parent or fails_in_base_and_merge_but_passes_in_a_single_parent

--- a/nimrod/dynamic_analysis/criteria/first_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/first_semantic_conflict_criteria.py
@@ -1,0 +1,17 @@
+from operator import xor
+
+from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import \
+    DynamicAnalysisCriteria
+from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import \
+    TestCaseExecutionInMergeScenario
+from nimrod.test_suites_execution.test_case_result import TestCaseResult
+
+
+class FirstSemanticConflictCriteria(DynamicAnalysisCriteria):
+    def is_satisfied_by(self, test_case_execution: TestCaseExecutionInMergeScenario) -> bool:
+        passes_in_base_and_merge_but_fails_in_a_single_parent = \
+            test_case_execution.merge == TestCaseResult.PASS \
+            and test_case_execution.base == TestCaseResult.PASS \
+            and bool(xor(test_case_execution.left == TestCaseResult.FAIL, test_case_execution.right == TestCaseResult.FAIL))
+
+        return passes_in_base_and_merge_but_fails_in_a_single_parent

--- a/nimrod/dynamic_analysis/criteria/first_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/first_semantic_conflict_criteria.py
@@ -14,4 +14,9 @@ class FirstSemanticConflictCriteria(DynamicAnalysisCriteria):
             and test_case_execution.base == TestCaseResult.PASS \
             and bool(xor(test_case_execution.left == TestCaseResult.FAIL, test_case_execution.right == TestCaseResult.FAIL))
 
-        return passes_in_base_and_merge_but_fails_in_a_single_parent
+        fails_in_base_and_merge_but_passes_in_a_single_parent = \
+            test_case_execution.merge == TestCaseResult.FAIL \
+            and test_case_execution.base == TestCaseResult.FAIL \
+            and bool(xor(test_case_execution.left == TestCaseResult.PASS, test_case_execution.right == TestCaseResult.PASS))
+
+        return passes_in_base_and_merge_but_fails_in_a_single_parent or fails_in_base_and_merge_but_passes_in_a_single_parent

--- a/nimrod/dynamic_analysis/criteria/first_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/first_semantic_conflict_criteria.py
@@ -1,13 +1,11 @@
-from operator import xor
-
-from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import \
-    DynamicAnalysisCriteria
+from nimrod.dynamic_analysis.criteria.semantic_conflict_criteria import \
+    SemanticConflictCriteria
 from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import \
     TestCaseExecutionInMergeScenario
 from nimrod.test_suites_execution.test_case_result import TestCaseResult
 
 
-class FirstSemanticConflictCriteria(DynamicAnalysisCriteria):
+class FirstSemanticConflictCriteria(SemanticConflictCriteria):
     def is_satisfied_by(self, test_case_execution: TestCaseExecutionInMergeScenario) -> bool:
         passes_in_base_and_merge_but_fails_in_a_single_parent = \
             test_case_execution.merge == TestCaseResult.PASS \

--- a/nimrod/dynamic_analysis/criteria/second_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/second_semantic_conflict_criteria.py
@@ -1,11 +1,11 @@
-from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import \
-    DynamicAnalysisCriteria
+from nimrod.dynamic_analysis.criteria.semantic_conflict_criteria import \
+    SemanticConflictCriteria
 from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import \
     TestCaseExecutionInMergeScenario
 from nimrod.test_suites_execution.test_case_result import TestCaseResult
 
 
-class SecondSemanticConflictCriteria(DynamicAnalysisCriteria):
+class SecondSemanticConflictCriteria(SemanticConflictCriteria):
   def is_satisfied_by(self, test_case_execution: TestCaseExecutionInMergeScenario) -> bool:
     fails_in_base_and_both_parents_but_passes_in_merge = \
         test_case_execution.base == TestCaseResult.FAIL \

--- a/nimrod/dynamic_analysis/criteria/second_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/second_semantic_conflict_criteria.py
@@ -1,0 +1,22 @@
+from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import \
+    DynamicAnalysisCriteria
+from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import \
+    TestCaseExecutionInMergeScenario
+from nimrod.test_suites_execution.test_case_result import TestCaseResult
+
+
+class SecondSemanticConflictCriteria(DynamicAnalysisCriteria):
+  def is_satisfied_by(self, test_case_execution: TestCaseExecutionInMergeScenario) -> bool:
+    fails_in_base_and_both_parents_but_passes_in_merge = \
+        test_case_execution.base == TestCaseResult.FAIL \
+        and test_case_execution.left == TestCaseResult.FAIL \
+        and test_case_execution.right == TestCaseResult.FAIL \
+        and test_case_execution.merge == TestCaseResult.PASS
+
+    passes_in_base_and_both_parents_but_fails_in_merge = \
+        test_case_execution.base == TestCaseResult.PASS \
+        and test_case_execution.left == TestCaseResult.PASS \
+        and test_case_execution.right == TestCaseResult.PASS \
+        and test_case_execution.merge == TestCaseResult.FAIL
+
+    return fails_in_base_and_both_parents_but_passes_in_merge or passes_in_base_and_both_parents_but_fails_in_merge

--- a/nimrod/dynamic_analysis/criteria/semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/semantic_conflict_criteria.py
@@ -4,7 +4,7 @@ from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import \
     TestCaseExecutionInMergeScenario
 
 
-class DynamicAnalysisCriteria(ABC):
+class SemanticConflictCriteria(ABC):
   @abstractmethod
   def is_satisfied_by(self, test_case_execution: TestCaseExecutionInMergeScenario) -> bool:
     pass

--- a/nimrod/dynamic_analysis/criteria/test_first_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/test_first_semantic_conflict_criteria.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+from nimrod.dynamic_analysis.criteria.first_semantic_conflict_criteria import \
+    FirstSemanticConflictCriteria
+from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import \
+    TestCaseExecutionInMergeScenario
+from nimrod.test_suites_execution.test_case_result import TestCaseResult
+
+
+class TestFirstSemanticConflictCriteria(TestCase):
+    def test_is_satisfied_if_it_passes_in_base_and_merge_but_breaks_in_a_single_parent(self):
+        scenario = TestCaseExecutionInMergeScenario(
+            test_suite=None,
+            name="test001",
+            base=TestCaseResult.PASS,
+            merge=TestCaseResult.PASS,
+            left=TestCaseResult.FAIL,
+            right=TestCaseResult.NOT_EXECUTABLE
+        )
+
+        self.assertTrue(FirstSemanticConflictCriteria().is_satisfied_by(scenario))

--- a/nimrod/dynamic_analysis/criteria/test_first_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/test_first_semantic_conflict_criteria.py
@@ -26,8 +26,8 @@ class TestFirstSemanticConflictCriteria(TestCase):
             name="test001",
             base=TestCaseResult.FAIL,
             merge=TestCaseResult.FAIL,
-            left=TestCaseResult.PASS,
-            right=TestCaseResult.NOT_EXECUTABLE
+            left=TestCaseResult.NOT_EXECUTABLE,
+            right=TestCaseResult.PASS
         )
 
         self.assertTrue(FirstSemanticConflictCriteria().is_satisfied_by(scenario))

--- a/nimrod/dynamic_analysis/criteria/test_first_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/test_first_semantic_conflict_criteria.py
@@ -8,13 +8,25 @@ from nimrod.test_suites_execution.test_case_result import TestCaseResult
 
 
 class TestFirstSemanticConflictCriteria(TestCase):
-    def test_is_satisfied_if_it_passes_in_base_and_merge_but_breaks_in_a_single_parent(self):
+    def test_is_satisfied_if_it_passes_in_base_and_merge_but_fails_in_a_single_parent(self):
         scenario = TestCaseExecutionInMergeScenario(
             test_suite=None,
             name="test001",
             base=TestCaseResult.PASS,
             merge=TestCaseResult.PASS,
             left=TestCaseResult.FAIL,
+            right=TestCaseResult.NOT_EXECUTABLE
+        )
+
+        self.assertTrue(FirstSemanticConflictCriteria().is_satisfied_by(scenario))
+
+    def test_is_satisfied_if_it_fails_in_base_and_merge_but_passes_in_a_single_parent(self):
+        scenario = TestCaseExecutionInMergeScenario(
+            test_suite=None,
+            name="test001",
+            base=TestCaseResult.FAIL,
+            merge=TestCaseResult.FAIL,
+            left=TestCaseResult.PASS,
             right=TestCaseResult.NOT_EXECUTABLE
         )
 

--- a/nimrod/dynamic_analysis/criteria/test_second_semantic_conflict_criteria.py
+++ b/nimrod/dynamic_analysis/criteria/test_second_semantic_conflict_criteria.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+
+from nimrod.dynamic_analysis.criteria.second_semantic_conflict_criteria import \
+    SecondSemanticConflictCriteria
+from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import \
+    TestCaseExecutionInMergeScenario
+from nimrod.test_suites_execution.test_case_result import TestCaseResult
+
+
+class TestSecondSemanticConflictCriteria(TestCase):
+  def test_is_satisfied_if_it_fails_in_base_and_in_both_parents_but_passes_in_merge(self):
+    scenario = TestCaseExecutionInMergeScenario(
+        test_suite=None,
+        name="test001",
+        base=TestCaseResult.FAIL,
+        left=TestCaseResult.FAIL,
+        right=TestCaseResult.FAIL,
+        merge=TestCaseResult.PASS,
+    )
+
+    self.assertTrue(SecondSemanticConflictCriteria().is_satisfied_by(scenario))
+
+  def test_is_satisfied_if_it_passes_in_base_and_in_both_parents_but_fails_in_merge(self):
+    scenario = TestCaseExecutionInMergeScenario(
+        test_suite=None,
+        name="test001",
+        base=TestCaseResult.PASS,
+        left=TestCaseResult.PASS,
+        right=TestCaseResult.PASS,
+        merge=TestCaseResult.FAIL,
+    )
+
+    self.assertTrue(SecondSemanticConflictCriteria().is_satisfied_by(scenario))

--- a/nimrod/dynamic_analysis/main.py
+++ b/nimrod/dynamic_analysis/main.py
@@ -1,14 +1,17 @@
 from typing import List
+from nimrod.dynamic_analysis.behavior_change import BehaviorChange
+from nimrod.dynamic_analysis.behavior_change_checker import BehaviorChangeChecker
 from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import DynamicAnalysisCriteria
 from nimrod.dynamic_analysis.semantic_conflict import SemanticConflict
 from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import TestCaseExecutionInMergeScenario
 
 
 class DynamicAnalysis:
-    def __init__(self, semantic_conflict_criterias: List[DynamicAnalysisCriteria]):
+    def __init__(self, semantic_conflict_criterias: List[DynamicAnalysisCriteria], behavior_change_checker: BehaviorChangeChecker):
         self._semantic_conflict_criterias = semantic_conflict_criterias
+        self._behavior_change_checker = behavior_change_checker
 
-    def check_for_semantic_conflicts(self, test_case_executions: List[TestCaseExecutionInMergeScenario]):
+    def check_for_semantic_conflicts(self, test_case_executions: List[TestCaseExecutionInMergeScenario]) -> List[SemanticConflict]:
         conflicts = []
 
         for test_case_execution in test_case_executions:
@@ -20,3 +23,18 @@ class DynamicAnalysis:
                     ))
 
         return conflicts
+
+    def check_for_behavior_changes(self, test_case_executions: List[TestCaseExecutionInMergeScenario]) -> List[BehaviorChange]:
+        behavior_changes = []
+
+        for execution in test_case_executions:
+            if self._behavior_change_checker.has_behavior_change_between(execution.base, execution.left):
+                behavior_changes.append(BehaviorChange(execution, ("BASE", "LEFT")))
+            if self._behavior_change_checker.has_behavior_change_between(execution.base, execution.right):
+                behavior_changes.append(BehaviorChange(execution, ("BASE", "RIGHT")))
+            if self._behavior_change_checker.has_behavior_change_between(execution.left, execution.merge):
+                behavior_changes.append(BehaviorChange(execution, ("LEFT", "MERGE")))
+            if self._behavior_change_checker.has_behavior_change_between(execution.right, execution.merge):
+                behavior_changes.append(BehaviorChange(execution, ("RIGHT", "MERGE")))
+
+        return behavior_changes

--- a/nimrod/dynamic_analysis/main.py
+++ b/nimrod/dynamic_analysis/main.py
@@ -1,0 +1,7 @@
+from typing import List
+from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import TestCaseExecutionInMergeScenario
+
+
+class DynamicAnalysis:
+  def check_for_semantic_conflicts(self, test_case_executions: List[TestCaseExecutionInMergeScenario]):
+    pass

--- a/nimrod/dynamic_analysis/main.py
+++ b/nimrod/dynamic_analysis/main.py
@@ -1,13 +1,13 @@
 from typing import List
 from nimrod.dynamic_analysis.behavior_change import BehaviorChange
 from nimrod.dynamic_analysis.behavior_change_checker import BehaviorChangeChecker
-from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import DynamicAnalysisCriteria
+from nimrod.dynamic_analysis.criteria.semantic_conflict_criteria import SemanticConflictCriteria
 from nimrod.dynamic_analysis.semantic_conflict import SemanticConflict
 from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import TestCaseExecutionInMergeScenario
 
 
 class DynamicAnalysis:
-    def __init__(self, semantic_conflict_criterias: List[DynamicAnalysisCriteria], behavior_change_checker: BehaviorChangeChecker):
+    def __init__(self, semantic_conflict_criterias: List[SemanticConflictCriteria], behavior_change_checker: BehaviorChangeChecker):
         self._semantic_conflict_criterias = semantic_conflict_criterias
         self._behavior_change_checker = behavior_change_checker
 

--- a/nimrod/dynamic_analysis/main.py
+++ b/nimrod/dynamic_analysis/main.py
@@ -1,23 +1,22 @@
 from typing import List
 from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import DynamicAnalysisCriteria
+from nimrod.dynamic_analysis.semantic_conflict import SemanticConflict
 from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import TestCaseExecutionInMergeScenario
 
 
-class SemanticConflict:
-  def __init__(self, satisfying_criteria: DynamicAnalysisCriteria, detected_in: TestCaseExecutionInMergeScenario) -> None:
-    self._satisfying_criteria = satisfying_criteria
-    self._detected_in = detected_in
-
 class DynamicAnalysis:
-  def __init__(self, semantic_conflict_criterias: List[DynamicAnalysisCriteria]):
-    self._semantic_conflict_criterias = semantic_conflict_criterias
+    def __init__(self, semantic_conflict_criterias: List[DynamicAnalysisCriteria]):
+        self._semantic_conflict_criterias = semantic_conflict_criterias
 
-  def check_for_semantic_conflicts(self, test_case_executions: List[TestCaseExecutionInMergeScenario]):
-    conflicts = []
+    def check_for_semantic_conflicts(self, test_case_executions: List[TestCaseExecutionInMergeScenario]):
+        conflicts = []
 
-    for test_case_execution in test_case_executions:
-      for criteria in self._semantic_conflict_criterias:
-        if criteria.is_satisfied_by(test_case_execution):
-          conflicts.append(SemanticConflict(criteria, test_case_execution))
+        for test_case_execution in test_case_executions:
+            for criteria in self._semantic_conflict_criterias:
+                if criteria.is_satisfied_by(test_case_execution):
+                    conflicts.append(SemanticConflict(
+                        satisfying_criteria=criteria,
+                        detected_in=test_case_execution
+                    ))
 
-    return conflicts
+        return conflicts

--- a/nimrod/dynamic_analysis/main.py
+++ b/nimrod/dynamic_analysis/main.py
@@ -1,7 +1,23 @@
 from typing import List
+from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import DynamicAnalysisCriteria
 from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import TestCaseExecutionInMergeScenario
 
 
+class SemanticConflict:
+  def __init__(self, satisfying_criteria: DynamicAnalysisCriteria, detected_in: TestCaseExecutionInMergeScenario) -> None:
+    self._satisfying_criteria = satisfying_criteria
+    self._detected_in = detected_in
+
 class DynamicAnalysis:
+  def __init__(self, semantic_conflict_criterias: List[DynamicAnalysisCriteria]):
+    self._semantic_conflict_criterias = semantic_conflict_criterias
+
   def check_for_semantic_conflicts(self, test_case_executions: List[TestCaseExecutionInMergeScenario]):
-    pass
+    conflicts = []
+
+    for test_case_execution in test_case_executions:
+      for criteria in self._semantic_conflict_criterias:
+        if criteria.is_satisfied_by(test_case_execution):
+          conflicts.append(SemanticConflict(criteria, test_case_execution))
+
+    return conflicts

--- a/nimrod/dynamic_analysis/semantic_conflict.py
+++ b/nimrod/dynamic_analysis/semantic_conflict.py
@@ -1,9 +1,9 @@
 
-from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import DynamicAnalysisCriteria
+from nimrod.dynamic_analysis.criteria.semantic_conflict_criteria import SemanticConflictCriteria
 from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import TestCaseExecutionInMergeScenario
 
 
 class SemanticConflict:
-    def __init__(self, satisfying_criteria: DynamicAnalysisCriteria, detected_in: TestCaseExecutionInMergeScenario) -> None:
+    def __init__(self, satisfying_criteria: SemanticConflictCriteria, detected_in: TestCaseExecutionInMergeScenario) -> None:
         self._satisfying_criteria = satisfying_criteria
         self._detected_in = detected_in

--- a/nimrod/dynamic_analysis/semantic_conflict.py
+++ b/nimrod/dynamic_analysis/semantic_conflict.py
@@ -1,0 +1,9 @@
+
+from nimrod.dynamic_analysis.criteria.dynamic_analysis_criteria import DynamicAnalysisCriteria
+from nimrod.test_suites_execution.test_case_execution_in_merge_scenario import TestCaseExecutionInMergeScenario
+
+
+class SemanticConflict:
+    def __init__(self, satisfying_criteria: DynamicAnalysisCriteria, detected_in: TestCaseExecutionInMergeScenario) -> None:
+        self._satisfying_criteria = satisfying_criteria
+        self._detected_in = detected_in

--- a/nimrod/dynamic_analysis/test_behavior_change_checker.py
+++ b/nimrod/dynamic_analysis/test_behavior_change_checker.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+
+from nimrod.dynamic_analysis.behavior_change_checker import \
+    BehaviorChangeChecker
+from nimrod.test_suites_execution.test_case_result import TestCaseResult
+
+
+class TestBehaviorChangeChecker(TestCase):
+  def get_bcc(self):
+    return BehaviorChangeChecker()
+
+  def test_there_is_a_behavior_change_if_it_fails_in_one_and_passes_in_the_other(self):
+    self.assertTrue(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.FAIL, TestCaseResult.PASS))
+    self.assertTrue(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.PASS, TestCaseResult.FAIL))
+
+  def test_there_is_not_a_behavior_change_if_either_one_of_the_tests_is_not_executable(self):
+    self.assertFalse(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.FAIL, TestCaseResult.NOT_EXECUTABLE))
+    self.assertFalse(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.NOT_EXECUTABLE, TestCaseResult.FAIL))
+
+    self.assertFalse(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.PASS, TestCaseResult.NOT_EXECUTABLE))
+    self.assertFalse(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.NOT_EXECUTABLE, TestCaseResult.PASS))
+
+  def test_there_is_not_a_behavior_change_if_either_one_of_the_tests_is_flaky(self):
+    self.assertFalse(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.FAIL, TestCaseResult.FLAKY))
+    self.assertFalse(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.FLAKY, TestCaseResult.FAIL))
+
+    self.assertFalse(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.PASS, TestCaseResult.FLAKY))
+    self.assertFalse(self.get_bcc().has_behavior_change_between(
+        TestCaseResult.FLAKY, TestCaseResult.PASS))

--- a/nimrod/smat.py
+++ b/nimrod/smat.py
@@ -1,4 +1,5 @@
 from typing import List
+from nimrod.dynamic_analysis.main import DynamicAnalysis
 from nimrod.input_parsing.smat_input import SmatInput
 from nimrod.test_suite_generation.main import TestSuiteGeneration
 from nimrod.test_suite_generation.test_suite import TestSuite
@@ -6,14 +7,15 @@ from nimrod.test_suites_execution.main import TestSuitesExecution
 
 
 class SMAT:
-  def __init__(self, test_suite_generation: TestSuiteGeneration, test_suites_execution: TestSuitesExecution) -> None:
+  def __init__(self, test_suite_generation: TestSuiteGeneration, test_suites_execution: TestSuitesExecution, dynamic_analisys: DynamicAnalysis) -> None:
     self._test_suite_generation = test_suite_generation
     self._test_suites_execution = test_suites_execution
+    self._dynamic_analysis = dynamic_analisys
 
   def run_tool_for_semmantic_conflict_detection(self, scenario: SmatInput) -> None:
     test_suites = self._generate_test_suites_for_scenario(scenario)
     executions = self._test_suites_execution.execute_test_suites(test_suites, scenario.scenario_jars)
-    
+    semantic_conflicts = self._dynamic_analysis.check_for_semantic_conflicts(executions)    
   
   def _generate_test_suites_for_scenario(self, scenario: SmatInput) -> List[TestSuite]:
       suites_left = self._test_suite_generation.generate_test_suites(scenario, scenario.scenario_jars.left)

--- a/nimrod/smat.py
+++ b/nimrod/smat.py
@@ -1,4 +1,6 @@
 from typing import List
+from nimrod.dynamic_analysis import behavior_change
+
 from nimrod.dynamic_analysis.main import DynamicAnalysis
 from nimrod.input_parsing.smat_input import SmatInput
 from nimrod.test_suite_generation.main import TestSuiteGeneration
@@ -16,13 +18,10 @@ class SMAT:
     test_suites = self._generate_test_suites_for_scenario(scenario)
     executions = self._test_suites_execution.execute_test_suites(test_suites, scenario.scenario_jars)
     semantic_conflicts = self._dynamic_analysis.check_for_semantic_conflicts(executions)    
+    behavior_changes = self._dynamic_analysis.check_for_behavior_changes(executions)
   
   def _generate_test_suites_for_scenario(self, scenario: SmatInput) -> List[TestSuite]:
-      suites_left = self._test_suite_generation.generate_test_suites(scenario, scenario.scenario_jars.left)
-      suites_right = self._test_suite_generation.generate_test_suites(scenario, scenario.scenario_jars.right)
+      suites_left = self._test_suite_generation.generate_test_suites(scenario, scenario.scenario_jars.left, True)
+      suites_right = self._test_suite_generation.generate_test_suites(scenario, scenario.scenario_jars.right, True)
 
       return suites_left + suites_right
-
-
-
-

--- a/nimrod/test_suite_generation/generators/evosuite_test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/evosuite_test_suite_generator.py
@@ -63,7 +63,7 @@ class EvosuiteTestSuiteGenerator(TestSuiteGenerator):
         return class_names
 
     # Evosuite needs to add its own Runtime in order to compile test suite
-    def _compile_test_suite(self, input_jar: str, output_path: str, extra_class_path: List[str] = []) -> List[str]:
+    def _compile_test_suite(self, input_jar: str, output_path: str, extra_class_path: List[str] = []) -> str:
         return super()._compile_test_suite(input_jar, output_path, [EVOSUITE_RUNTIME] + extra_class_path)
 
     def _create_method_list(self, methods: "List[str]"):

--- a/nimrod/test_suite_generation/generators/test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/test_suite_generator.py
@@ -58,7 +58,7 @@ class TestSuiteGenerator(ABC):
     def _get_test_suite_class_names(self, test_suite_path: str) -> List[str]:
         pass
 
-    def _compile_test_suite(self, input_jar: str, test_suite_path: str, extra_class_path: List[str] = []) -> List[str]:
+    def _compile_test_suite(self, input_jar: str, test_suite_path: str, extra_class_path: List[str] = []) -> str:
         compiled_classes_path = path.join(test_suite_path, 'classes')
         class_path = generate_classpath([input_jar, test_suite_path, compiled_classes_path, JUNIT, HAMCREST] + extra_class_path)
 

--- a/nimrod/test_suite_generation/test_suite.py
+++ b/nimrod/test_suite_generation/test_suite.py
@@ -2,7 +2,7 @@ from typing import List
 
 
 class TestSuite:
-    def __init__(self, generator_name: str, path: str, class_path: List[str], test_classes_names: List[str]) -> None:
+    def __init__(self, generator_name: str, path: str, class_path: str, test_classes_names: List[str]) -> None:
         self._generator_name = generator_name
         self._path = path
         self._class_path = class_path
@@ -17,7 +17,7 @@ class TestSuite:
         return self._path
 
     @property
-    def class_path(self) -> List[str]:
+    def class_path(self) -> str:
         return self._class_path
 
     @property

--- a/nimrod/test_suites_execution/test_suite_executor.py
+++ b/nimrod/test_suites_execution/test_suite_executor.py
@@ -47,8 +47,9 @@ class TestSuiteExecutor:
             classpath = generate_classpath([
                 JUNIT,
                 EVOSUITE_RUNTIME,
-                target_jar
-            ] + test_suite.class_path)
+                target_jar,
+                test_suite.class_path
+            ])
 
             params = [
                 '-classpath', classpath,


### PR DESCRIPTION
This refactor moves the Dynamic Analysis into a separate module.
```mermaid
classDiagram
    class DynamicAnalysis {
        +check_for_semmantic_conflicts(TestCaseExecutionInMergeScenario test_cases) SemanticConflict[]
        +check_for_behavior_changes(TestCaseExecutionInMergeScenario test_cases) BehaviorChange[]
    }
    DynamicAnalysis ..> TestCaseExecutionInMergeScenario
    DynamicAnalysis o-- SemanticConflictCriteria
    DynamicAnalysis ..> SemanticConflict
    DynamicAnalysis ..> BehaviorChange
    DynamicAnalysis --> BehaviorChangeChecker

    class SemanticConflict {
        + SemanticConflictCriteria satisfying_criteria
        + TestCaseExecutionInMergeScenario detected_in
    }

    class BehaviorChange {
        + TestCaseExecutionInMergeScenario detected_in
        + Tuple[str, str] between
    }

    class SemanticConflictCriteria {
        +is_satisfied_by(TestCaseExecutionInMergeScenario test_case_execution) boolean
    }
    SemanticConflictCriteria <|-- FirstSemanticConflictCriteria
    SemanticConflictCriteria <|-- SecondSemanticConflictCriteria

    class TestCaseExecutionInMergeScenario {
        +TestSuite test_suite
        +String name
        +TestCaseResult base
        +TestCaseResult left
        +TestCaseResult right
        +TestCaseResult merge
    }
    TestCaseExecutionInMergeScenario --> TestCaseResult
    class TestCaseResult {
        <<enumeration>>
        PASS
        FAIL
        FLAKY
        NOT_EXECUTABLE
    }

    class BehaviorChangeChecker {
      +has_behavior_change_between(TestCaseResult one, TestCaseResult two) bool
    }

```