### PR TITLE
[Test Suite Generation] - Add deterministic generation for Evosuite.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,9 @@ This property allows to customize the time **in seconds** provided for each gene
 ### generate_deterministic_test_suites
 If set to true, SMAT will use deterministic versions of its generators, i.e., the generated suites will always be the same regardless of how many times the code is executed.
 
+### test_suite_generation_seed
+When `generate_deterministic_test_suites` is set to true, this allows the user to customize the seed which will be provided for the generators implemented. Default value is `42`.
+
 ## Output Generation
 The following properties are related to the Output Generation step.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ The following properties are related to the Test Suites Generation step.
 This property consists of an array with the name of the Generators which will be used in SMAT during Test Suite Generation step. If not set, all the implemented generators will be used. Valid values are: `randoop`, `randoop-modified`, `evosuite` and `evosuite-differential`.
 
 ### test_suite_generation_search_budget
-This property allows to customize the time **in seconds** provided for each generator during Test Suite Generation. Default value is 300 seconds. Please note that this option will be ignored when using deterministic Test Suites.
+This property allows to customize the time **in seconds** provided for each generator during Test Suite Generation. Default value is 300 seconds. Please note that this option will be ignored when using deterministic Test Suites. Be aware that when using deterministic test suites generation, the budget time is ignored and other stopping criterias are applied, since different computing power can influence in the time required to generate the same test suite.
 
 ### generate_deterministic_test_suites
 If set to true, SMAT will use deterministic versions of its generators, i.e., the generated suites will always be the same regardless of how many times the code is executed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ This property allows to customize the time **in seconds** provided for each gene
 If set to true, SMAT will use deterministic versions of its generators, i.e., the generated suites will always be the same regardless of how many times the code is executed.
 
 ### test_suite_generation_seed
-When `generate_deterministic_test_suites` is set to true, this allows the user to customize the seed which will be provided for the generators implemented. Default value is `42`.
+When `generate_deterministic_test_suites` is set to true, the user customizes the seed that is provided for the invoked test generation tools. Default value is `42`.
 
 ## Output Generation
 The following properties are related to the Output Generation step.

--- a/nimrod/test_suite_generation/generators/evosuite_differential_test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/evosuite_differential_test_suite_generator.py
@@ -1,10 +1,8 @@
 import logging
-import os
-from typing import Dict, List
 from nimrod.core.merge_scenario_under_analysis import MergeScenarioUnderAnalysis
 
 from nimrod.test_suite_generation.generators.evosuite_test_suite_generator import EvosuiteTestSuiteGenerator
-from nimrod.tools.bin import EVOSUITE, EVOSUITE_RUNTIME
+from nimrod.tools.bin import EVOSUITE
 
 
 class EvosuiteDifferentialTestSuiteGenerator(EvosuiteTestSuiteGenerator):
@@ -20,9 +18,16 @@ class EvosuiteDifferentialTestSuiteGenerator(EvosuiteTestSuiteGenerator):
               '-projectCP', input_jar,
               f'-Dregressioncp={scenario.scenario_jars.base}',
               '-class', class_name,
-              f'-Dsearch_budget={self.SEARCH_BUDGET}',
               '-DOUTPUT_DIR=' + output_path,
+              '-Dminimize=false',
+              '-Djunit_check=false',
+              '-Dinline=false',
           ]
+          
+          if use_determinism:
+            params += ["-Dstopping_condition=MaxStatements", f"-seed={self.SEED}"]
+          else:
+            params += [f'-Dsearch_budget={self.SEARCH_BUDGET}']
 
           if(len(methods) > 0):
             params.append(

--- a/nimrod/test_suite_generation/generators/evosuite_test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/evosuite_test_suite_generator.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict, List
+from typing import List
 from nimrod.core.merge_scenario_under_analysis import MergeScenarioUnderAnalysis
 
 from nimrod.test_suite_generation.generators.test_suite_generator import \
@@ -10,8 +10,6 @@ from nimrod.tools.bin import EVOSUITE, EVOSUITE_RUNTIME
 
 
 class EvosuiteTestSuiteGenerator(TestSuiteGenerator):
-    SEARCH_BUDGET = int(get_config().get('test_suite_generation_search_budget', 300))
-
     def get_generator_tool_name(self) -> str:
         return "EVOSUITE"
 
@@ -22,18 +20,20 @@ class EvosuiteTestSuiteGenerator(TestSuiteGenerator):
               '-jar', EVOSUITE,
               '-projectCP', input_jar,
               '-class', class_name,
-              '-Dtimeout', '5',
               '-Dassertion_strategy=all',
               '-Dp_reflection_on_private=0',
               '-Dreflection_start_percent=0',
               '-Dp_functional_mocking=0',
               '-Dfunctional_mocking_percent=0',
               '-Dminimize=false',
-              f'-Dsearch_budget={self.SEARCH_BUDGET}',
               '-Djunit_check=false',
               '-Dinline=false',
-              '-DOUTPUT_DIR=' + output_path,
           ]
+          
+          if use_determinism:
+            params += ["-Dstopping_condition=MaxStatements", f"-seed={self.SEED}"]
+          else:
+            params += [f'-Dsearch_budget={self.SEARCH_BUDGET}']
 
           if(len(methods) > 0):
             params.append(

--- a/nimrod/test_suite_generation/generators/randoop_test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/randoop_test_suite_generator.py
@@ -4,14 +4,11 @@ from nimrod.core.merge_scenario_under_analysis import MergeScenarioUnderAnalysis
 
 from nimrod.test_suite_generation.generators.test_suite_generator import \
     TestSuiteGenerator
-from nimrod.tests.utils import get_config
 from nimrod.tools.java import Java
 from nimrod.utils import generate_classpath
 
 
 class RandoopTestSuiteGenerator(TestSuiteGenerator):
-    SEARCH_BUDGET = int(get_config().get('test_suite_generation_search_budget', 300))
-
     TARGET_METHODS_LIST_FILENAME = 'methods_to_test.txt'
     TARGET_CLASS_LIST_FILENAME = 'classes_to_test.txt'
 
@@ -34,7 +31,7 @@ class RandoopTestSuiteGenerator(TestSuiteGenerator):
         ]
 
         if use_determinism:
-            params += ["--randomseed=10",
+            params += [f"--randomseed={self.SEED}",
                        "--deterministic", "--time-limit=0", "--attempted-limit=4000"]
         else:
             params += [f"--time-limit={int(self.SEARCH_BUDGET)}"]

--- a/nimrod/test_suite_generation/generators/test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/test_suite_generator.py
@@ -4,6 +4,7 @@ from os import makedirs, path
 from time import time
 from typing import List
 
+from nimrod.tests.utils import get_config
 from nimrod.core.merge_scenario_under_analysis import MergeScenarioUnderAnalysis
 from nimrod.tests.utils import get_base_output_path
 from nimrod.test_suite_generation.test_suite import TestSuite

--- a/nimrod/test_suite_generation/generators/test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/test_suite_generator.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import logging
 from os import makedirs, path
 from time import time
-from typing import Dict, List
+from typing import List
 
 from nimrod.core.merge_scenario_under_analysis import MergeScenarioUnderAnalysis
 from nimrod.tests.utils import get_base_output_path
@@ -14,6 +14,9 @@ from nimrod.utils import generate_classpath
 
 
 class TestSuiteGenerator(ABC):
+    SEARCH_BUDGET = int(get_config().get('test_suite_generation_search_budget', 300))
+    SEED = int(get_config().get('test_suite_generation_seed', 42))
+
     def __init__(self, java: Java) -> None:
         self._java = java
 


### PR DESCRIPTION
This PR closes #5, introducing deterministic test suite generation for both Evosuite and Evosuite Differential. It also implements the missign `test_suite_generation_seed` configuration option, which allows the user to customize the seed used in deterministic test suite generation.