### PR TITLE
Behavior changes in test suite generator and executor modules

### DIFF
--- a/nimrod/test_suite_generation/generators/test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/test_suite_generator.py
@@ -70,6 +70,9 @@ class TestSuiteGenerator(ABC):
         class_path = generate_classpath([input_jar, test_suite_path, compiled_classes_path, JUNIT, HAMCREST] + extra_class_path)
 
         for java_file in self._get_test_suite_class_paths(test_suite_path):
-            self._java.exec_javac(java_file, test_suite_path, None, None,
-                                  '-classpath', class_path, '-d', compiled_classes_path)
+            try:
+                self._java.exec_javac(java_file, test_suite_path, None, None,
+                                    '-classpath', class_path, '-d', compiled_classes_path)
+            except:
+                pass
         return class_path

--- a/nimrod/test_suite_generation/generators/test_suite_generator.py
+++ b/nimrod/test_suite_generation/generators/test_suite_generator.py
@@ -3,6 +3,7 @@ import logging
 from os import makedirs, path
 from time import time
 from typing import List
+from subprocess import CalledProcessError
 
 from nimrod.tests.utils import get_config
 from nimrod.core.merge_scenario_under_analysis import MergeScenarioUnderAnalysis
@@ -73,6 +74,6 @@ class TestSuiteGenerator(ABC):
             try:
                 self._java.exec_javac(java_file, test_suite_path, None, None,
                                     '-classpath', class_path, '-d', compiled_classes_path)
-            except:
-                pass
+            except CalledProcessError:
+                logging.error("Error while compiling %s", java_file)
         return class_path

--- a/nimrod/test_suites_execution/test_suite_executor.py
+++ b/nimrod/test_suites_execution/test_suite_executor.py
@@ -85,11 +85,11 @@ class TestSuiteExecutor:
             test_run_count = 0
             if tests_run:
                 test_run_count = int(tests_run.group('tests_run_count'))
-            for i in range(0, test_run_count):
-                test_case_name = 'test{number:0{width}d}'.format(width=len(str(test_run_count)), number=i)
-                if not results.get(test_case_name):
-                    results[test_case_name] = TestCaseResult.PASS
- 
+                if results:
+                    for i in range(0, test_run_count):
+                        test_case_name = 'test{number:0{width}d}'.format(width=len(str(test_run_count)), number=i)
+                        if not results.get(test_case_name):
+                            results[test_case_name] = TestCaseResult.PASS
         return results
 
     def execute_test_suite_with_coverage(self, test_suite: TestSuite, target_jar: str, test_cases: List[str]) -> str:


### PR DESCRIPTION
### Correções Implementadas:

1. **Arquivo: `nimrod/test_suites_execution/test_suite_executor.py`**
   - **Problema:** Quando a `test_class` não era encontrada, a execução resultava em um erro que era interpretado como um teste falho. Porém, como o nome do teste não era encontrado, o resultado do teste era marcado como PASS, mesmo sem o teste existir de fato.
   - **Solução:** Incluído um `if` que mantém `results` como vazio caso a situação ocorra novamente.

2. **Arquivo: `nimrod/test_suite_generation/generators/test_suite_generator.py`**
   - **Problema:** Se algum dos arquivos Java (`java_file`) no diretório falhasse na compilação, todo o processo de compilação era interrompido.
   - **Solução:** Adicionado um bloco `try-except` para que, em caso de falha na compilação de um `java_file`, ele seja ignorado e o processo de compilação continue com os próximos arquivos.